### PR TITLE
workaround for crashing `clear-double-boot`

### DIFF
--- a/app/instance-initializers/fastboot-fix.js
+++ b/app/instance-initializers/fastboot-fix.js
@@ -19,6 +19,7 @@ export function initialize(/* appInstance */) {
 
 export default {
   name: 'fastboot-fix',
+  before: 'clear-double-boot',
 
   initialize,
 };

--- a/app/instance-initializers/fastboot-fix.js
+++ b/app/instance-initializers/fastboot-fix.js
@@ -1,0 +1,24 @@
+export function prepDomForFastBoot() {
+  let start = document.getElementById('fastboot-body-start');
+  let end = document.getElementById('fastboot-body-end');
+
+  if (!start || !end) {
+    return;
+  }
+
+  if (start.parentElement !== end.parentElement) {
+    start.parentElement.appendChild(end);
+  }
+}
+
+export function initialize(/* appInstance */) {
+  if (typeof FastBoot === 'undefined') {
+    prepDomForFastBoot();
+  }
+}
+
+export default {
+  name: 'fastboot-fix',
+
+  initialize,
+};

--- a/tests/integration/instance-initializers/fastboot-fix-test.js
+++ b/tests/integration/instance-initializers/fastboot-fix-test.js
@@ -1,0 +1,29 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Instance Initializer | fastboot-fix', function(hooks) {
+  setupRenderingTest(hooks);
+
+  // Replace this with your real tests.
+  test('it ensures fastboot markers have the same parent', async function(assert) {
+    const BAD_BODY = `
+      <script type="x/boundary" id="fastboot-body-start"></script>
+      <div>
+        <p>
+          Great article content here.
+        </p>
+        <em>With additional reporting<em>
+      </div>
+      <script type="x/boundary" id="fastboot-body-end"></script>
+    `;
+    this.set('BAD_BODY', BAD_BODY);
+
+    await render(hbs`{{{BAD_BODY}}}`);
+
+    let startMarker = this.element.querySelector('#fastboot-body-start');
+    let endMarker = this.element.querySelector('#fastboot-body-end');
+    assert.deepEqual(startMarker.parentElement, endMarker.parentElement);
+  });
+});

--- a/tests/integration/instance-initializers/fastboot-fix-test.js
+++ b/tests/integration/instance-initializers/fastboot-fix-test.js
@@ -1,3 +1,4 @@
+import { prepDomForFastBoot } from 'gothamist-web-client/instance-initializers/fastboot-fix';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
@@ -21,6 +22,8 @@ module('Integration | Instance Initializer | fastboot-fix', function(hooks) {
     this.set('BAD_BODY', BAD_BODY);
 
     await render(hbs`{{{BAD_BODY}}}`);
+
+    prepDomForFastBoot();
 
     let startMarker = this.element.querySelector('#fastboot-body-start');
     let endMarker = this.element.querySelector('#fastboot-body-end');


### PR DESCRIPTION
Fastboot includes some initial DOM parsing to clear server-rendered content (not entirely unlike our `django-for-ember` addon). The problem is that there are some assumptions about the DOM tree that can cause the app to crash if things are not structured 👌just so👌.

This patch includes a work around to the issue in `ember-cli-fastboot`.

I've opened a pr at ember-fastboot/ember-cli-fastboot#699 to fix this issue. Hopefully they will accept it and we won't need this bit of code.

[ticket](https://jira.wnyc.org/browse/DS-223)