### PR TITLE
Mwalsh/ads fixes

### DIFF
--- a/app/components/ad-tag-leaderboard/template.hbs
+++ b/app/components/ad-tag-leaderboard/template.hbs
@@ -9,6 +9,7 @@
       (array 728 90)
     )
     (array 1000
+      (array 970 250)
       (array 970 90)
       (array 728 90)
     )
@@ -17,5 +18,6 @@
     (array 320 50)
     (array 728 90)
     (array 970 90)
+    (array 970 250)
   }}
 />

--- a/app/components/ad-tag-leaderboard/template.hbs
+++ b/app/components/ad-tag-leaderboard/template.hbs
@@ -5,7 +5,7 @@
     (array 0
       (array 320 50)
     )
-    (array 800
+    (array 750
       (array 728 90)
     )
     (array 1000

--- a/app/components/ad-tag-tall/template.hbs
+++ b/app/components/ad-tag-tall/template.hbs
@@ -5,7 +5,7 @@
     (array 0
       (array 300 250)
     )
-    (array 800
+    (array 750
       (array 300 600)
       (array 300 250)
     )

--- a/app/components/ad-tag-wide/template.hbs
+++ b/app/components/ad-tag-wide/template.hbs
@@ -16,12 +16,14 @@
           (array 970 250)
           (array 970 90)
           (array 728 90)
+          (array 300 600)
           (array 300 250)
         )
       }}
       @sizes={{array
         (array 320 50)
         (array 300 250)
+        (array 300 600)
         (array 728 90)
         (array 970 90)
         (array 970 250)

--- a/app/components/ad-tag-wide/template.hbs
+++ b/app/components/ad-tag-wide/template.hbs
@@ -13,6 +13,7 @@
           (array 300 250)
         )
         (array 1000
+          (array 970 250)
           (array 970 90)
           (array 728 90)
           (array 300 250)
@@ -23,6 +24,7 @@
         (array 300 250)
         (array 728 90)
         (array 970 90)
+        (array 970 250)
       }}
       data-test-ad-tag-wide
     />

--- a/app/components/ad-tag-wide/template.hbs
+++ b/app/components/ad-tag-wide/template.hbs
@@ -8,7 +8,7 @@
         (array 0
           (array 320 50)
         )
-        (array 800
+        (array 750
           (array 728 90)
           (array 300 250)
         )

--- a/app/routes/404.js
+++ b/app/routes/404.js
@@ -27,7 +27,10 @@ export default Route.extend({
         nav: true,
         search: true,
         donate: true,
-      }
+      },
+      resting: {
+        leaderboard: true,
+      },
     });
 
     return this.store.query('article', {

--- a/app/routes/500.js
+++ b/app/routes/500.js
@@ -20,7 +20,10 @@ export default Route.extend({
         nav: true,
         search: true,
         donate: true,
-      }
+      },
+      resting: {
+        leaderboard: true,
+      },
     });
   },
 

--- a/app/routes/article/index.js
+++ b/app/routes/article/index.js
@@ -27,6 +27,7 @@ export default Route.extend({
         search: true,
       },
       resting: {
+        leaderboard: true,
         nav: true,
       },
       floating: {

--- a/app/routes/author-detail.js
+++ b/app/routes/author-detail.js
@@ -23,7 +23,10 @@ export default Route.extend({
         nav: true,
         donate: true,
         search: true,
-      }
+      },
+      resting: {
+        leaderboard: true,
+      },
     });
   },
 

--- a/app/routes/contact.js
+++ b/app/routes/contact.js
@@ -15,7 +15,10 @@ export default Route.extend({
         nav: true,
         donate: true,
         search: true,
-      }
+      },
+      resting: {
+        leaderboard: true,
+      },
     });
   },
 

--- a/app/routes/popular.js
+++ b/app/routes/popular.js
@@ -26,7 +26,10 @@ export default Route.extend({
         nav: true,
         search: true,
         donate: true,
-      }
+      },
+      resting: {
+        leaderboard: true,
+      },
     });
   },
 

--- a/app/routes/search.js
+++ b/app/routes/search.js
@@ -15,7 +15,10 @@ export default Route.extend({
         nav: true,
         donate: true,
         search: true,
-      }
+      },
+      resting: {
+        leaderboard: true,
+      },
     });
   }
 });

--- a/app/routes/sections.js
+++ b/app/routes/sections.js
@@ -28,6 +28,9 @@ export default Route.extend({
         donate: true,
         search: true,
       },
+      resting: {
+        leaderboard: true,
+      },
     });
   },
 

--- a/app/routes/staff.js
+++ b/app/routes/staff.js
@@ -12,7 +12,10 @@ export default Route.extend({
         nav: true,
         donate: true,
         search: true,
-      }
+      },
+      resting: {
+        leaderboard: true,
+      },
     });
   },
 

--- a/app/routes/tags.js
+++ b/app/routes/tags.js
@@ -34,6 +34,9 @@ export default Route.extend({
         donate: true,
         search: true,
       },
+      resting: {
+        leaderboard: true,
+      },
     });
   },
 

--- a/app/templates/article/gallery.hbs
+++ b/app/templates/article/gallery.hbs
@@ -12,8 +12,9 @@
   {{#if (eq (mod index 3) 2)}}
     {{!-- No more than 2 inline ads on one page --}}
     {{#if (lt index 6)}}
-      <gallery.billboard>
-        <AdTagWide @slot="gothamist/interior/midpage/gallery" />
+      <gallery.billboard @hideLabel={{true}}>
+        <AdTagWide @slot="gothamist/interior/midpage/gallery"
+        @showLabel={{true}} />
       </gallery.billboard>
     {{/if}}
   {{/if}}

--- a/app/templates/article/gallery.hbs
+++ b/app/templates/article/gallery.hbs
@@ -12,7 +12,7 @@
   {{#if (eq (mod index 3) 2)}}
     {{!-- No more than 2 inline ads on one page --}}
     {{#if (lt index 6)}}
-      <gallery.billboard @hideLabel={{true}}>
+      <gallery.billboard>
         <AdTagWide @slot="gothamist/interior/midpage/gallery"
         @showLabel={{true}} />
       </gallery.billboard>

--- a/tests/integration/modifiers/insert-target-test.js
+++ b/tests/integration/modifiers/insert-target-test.js
@@ -63,7 +63,7 @@ module('Integration | Modifier | insert-target', function(hooks) {
     assert.deepEqual(elementList, ['p1','p2','h2','p3','trgt','p4']);
   });
 
-  test('it should not display ads directly above or below social embed or video', async function(assert) {
+  test('it should not display ads directly between a paragraph followed by an embed', async function(assert) {
     await render(hbs`<div {{insert-target 'trgt' wordBoundary=300}}>
       <p id="p1">{{this.oneHundredWords}}</p>
       <p id="p2">{{this.oneHundredWords}}</p>
@@ -74,8 +74,22 @@ module('Integration | Modifier | insert-target', function(hooks) {
     </div>`);
     let elementList = [...this.element.firstChild.children].map(el => el.id);
     assert.dom('div#trgt').exists({count: 1});
-    assert.deepEqual(elementList, ['p1','p2','p3','iframe','p4','trgt','p5']);
+    assert.deepEqual(elementList, ['p1','p2','p3','iframe','trgt','p4','p5']);
   });
+
+
+  test('it should weight embeds as 50 words', async function(assert) {
+    await render(hbs`<div {{insert-target 'trgt' wordBoundary=150}}>
+      <iframe id="iframe1"></iframe>
+      <iframe id="iframe2"></iframe>
+      <iframe id="iframe3"></iframe>
+      <iframe id="iframe4"></iframe>
+    </div>`);
+    let elementList = [...this.element.firstChild.children].map(el => el.id);
+    assert.dom('div#trgt').exists({count: 1});
+    assert.deepEqual(elementList, ['iframe1','iframe2','iframe3','trgt','iframe4']);
+  });
+
 
   test('it should handle bare text nodes part 1', async function(assert) {
     await render(hbs`<div {{insert-target 'trgt' wordBoundary=300}}>
@@ -127,18 +141,16 @@ module('Integration | Modifier | insert-target', function(hooks) {
   });
 
   test('it should insert at the end if all else fails', async function(assert) {
-    await render(hbs`<div {{insert-target 'trgt' wordBoundary=300}}>
+    await render(hbs`<div {{insert-target 'trgt' wordBoundary=100}}>
+      <h1 id="h1">{{this.oneHundredWords}}</h1>
+      <h2 id="h2">{{this.oneHundredWords}}</h2>
+      <h3 id="h3">{{this.oneHundredWords}}</h3>
+      <h4 id="h4">{{this.oneHundredWords}}</h4>
       <p id="p1">{{this.oneHundredWords}}</p>
-      <iframe id="iframe"></iframe>
-      <p id="p2">{{this.oneHundredWords}}</p>
-      <iframe id="iframe"></iframe>
-      <p id="p3">{{this.oneHundredWords}}</p>
-      <iframe id="iframe"></iframe>
-      <p id="p4">{{this.oneHundredWords}}</p>
       <iframe id="iframe"></iframe>
     </div>`);
     let elementList = [...this.element.firstChild.children].map(el => el.id);
     assert.dom('div#trgt').exists({count: 1});
-    assert.deepEqual(elementList, ['p1','iframe','p2','iframe','p3','iframe','p4','iframe','trgt']);
+    assert.deepEqual(elementList, ['h1','h2','h3','h4','p1','iframe','trgt']);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8866,7 +8866,7 @@ nypr-auth@^0.2.4:
 
 nypr-design-system@nypublicradio/nypr-design-system:
   version "0.2.0"
-  resolved "https://codeload.github.com/nypublicradio/nypr-design-system/tar.gz/7df0317fe7be6ec8aa014225ae098a062eb34379"
+  resolved "https://codeload.github.com/nypublicradio/nypr-design-system/tar.gz/f5fc4114aa6e6a56f66b27fe3d0febe7c72352e8"
   dependencies:
     broccoli-merge-files "^0.8.0"
     ember-auto-import "^1.2.19"
@@ -8907,7 +8907,7 @@ nypr-metrics@nypublicradio/nypr-metrics:
   version "0.5.4"
   resolved "https://codeload.github.com/nypublicradio/nypr-metrics/tar.gz/b09905f3cfc80597498038c745bd4314865df939"
   dependencies:
-    ember-cli-babel "^7.0.0"
+    ember-cli-babel "^6.6.0"
     ember-get-config "^0.2.2"
 
 oauth-sign@~0.9.0:
@@ -10871,9 +10871,9 @@ tar-stream@^1.5.0:
     xtend "^4.0.0"
 
 tar@^4:
-  version "4.4.9"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.9.tgz#058fbb152f6fc45733e84585a40c39e59302e1b3"
-  integrity sha512-xisFa7Q2i3HOgfn+nmnWLGHD6Tm23hxjkx6wwGmgxkJFr6wxwXnJOdJYcZjL453PSdF0+bemO03+flAzkIdLBQ==
+  version "4.4.10"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.10.tgz#946b2810b9a5e0b26140cf78bea6b0b0d689eba1"
+  integrity sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==
   dependencies:
     chownr "^1.1.1"
     fs-minipass "^1.2.5"


### PR DESCRIPTION
- Update ad insertion with new rules
  - Inserting before or after embeds is okay (just not between a paragraph followed by an embed)
  - When deciding where to insert ads weigh embeds as at least 50 words each
- Update breakpoints on the ad slots to match what we have in pattern lab
- Add the 970x250 ad unit size to the leaderboard (https://jira.wnyc.org/browse/DS-321)
- For billboards in galleries, use the label from the ad component instead of the label from the template wrapper. This makes it easier for us to align the label when centering
- Add a header rule to all routes so we can see the leaderboard ad unit on all pages (https://jira.wnyc.org/browse/DS-173 https://jira.wnyc.org/browse/DS-320)
- Make  midpage ads support bigger sizes (https://jira.wnyc.org/browse/DS-172 https://jira.wnyc.org/browse/DS-174)