### PR TITLE
WNYC title

### DIFF
--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -78,6 +78,7 @@
     <~fbl.heading class="c-featured-blocks__heading--wnyc">
       <span class="o-bg-text-accent">
         New From
+        <span class="is-vishidden">WNYC</span>
         <NyprASvg @icon='wnyc-logo'/>
       </span>
    </~fbl.heading>


### PR DESCRIPTION
Needed to have screenreaders recognize WNYC title, which comes from svg. VO didn't read svg title in h2, so included as a span.is-vishidden instead.