### PR TITLE
DS-319: Use 'index' ad slot for leaderboard on homepage

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -9,7 +9,7 @@
   as |header|>
 
   <header.leaderboard>
-    {{#if header.rules.homepage}}
+    {{#if (eq target.currentRouteName 'index')}}
       <AdTagLeaderboard @slot='gothamist/index/leaderboard' />
     {{else}}
       <AdTagLeaderboard @slot='gothamist/interior/leaderboard' />


### PR DESCRIPTION
This changes the leaderboard check from `header.rules.homepage` to `eq target.currentRouteName 'index'`, which is what we use elsewhere in that template (https://github.com/nypublicradio/gothamist-web-client/blob/77b9112bee602562c8191e28117a9bdde8a4afd0/app/templates/application.hbs#L6) to determine if we're on the homepage.