### PR TITLE
DS-341 home page ad margins

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -113,6 +113,11 @@ $ember-basic-dropdown-content-z-index: 10000;
   }
 }
 
+// margin for ads when columns collapse
+.c-home__sections .c-block-group__col1 {
+  margin-bottom: 24px;
+}
+
 // ad layout
 .break-margins {
   position: absolute;

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -113,9 +113,12 @@ $ember-basic-dropdown-content-z-index: 10000;
   }
 }
 
-// margin for ads when columns collapse
+// margin and width for ads when columns collapse
 .c-home__sections .c-block-group__col1 {
   margin-bottom: 24px;
+}
+.c-home__sections .c-block-group__col2 .o-ad {
+  width: 300px;
 }
 
 // ad layout


### PR DESCRIPTION
https://jira.wnyc.org/browse/DS-341

Adds some margin and a width to keep the label aligned.

This css should maybe be moved into pattern lab at some point but we can do that later if it turns out we want to.