### PR TITLE
Make sure all ad sizes are requested

### DIFF
--- a/app/components/ad-tag-leaderboard/template.hbs
+++ b/app/components/ad-tag-leaderboard/template.hbs
@@ -3,15 +3,21 @@
   @target={{@target}}
   @mapping={{array
     (array 0
-      (array 320 50)
+      (array
+        (array 320 50)
+      )
     )
     (array 750
-      (array 728 90)
+      (array
+        (array 728 90)
+      )
     )
     (array 1000
-      (array 970 250)
-      (array 970 90)
-      (array 728 90)
+      (array
+        (array 970 250)
+        (array 970 90)
+        (array 728 90)
+      )
     )
   }}
   @sizes={{array

--- a/app/components/ad-tag-tall/template.hbs
+++ b/app/components/ad-tag-tall/template.hbs
@@ -3,11 +3,15 @@
   @target={{@target}}
   @mapping={{array
     (array 0
-      (array 300 250)
+      (array
+        (array 300 250)
+      )
     )
     (array 750
-      (array 300 600)
-      (array 300 250)
+      (array
+        (array 300 600)
+        (array 300 250)
+      )
     )
   }}
   @sizes={{array

--- a/app/components/ad-tag-wide/template.hbs
+++ b/app/components/ad-tag-wide/template.hbs
@@ -6,18 +6,24 @@
       @slotRenderEndedAction={{action 'handleSlotRendered'}}
       @mapping={{array
         (array 0
-          (array 320 50)
+          (array
+            (array 320 50)
+          )
         )
         (array 750
-          (array 728 90)
-          (array 300 250)
+          (array
+            (array 728 90)
+            (array 300 250)
+          )
         )
         (array 1000
-          (array 970 250)
-          (array 970 90)
-          (array 728 90)
-          (array 300 600)
-          (array 300 250)
+          (array
+            (array 970 250)
+            (array 970 90)
+            (array 728 90)
+            (array 300 600)
+            (array 300 250)
+          )
         )
       }}
       @sizes={{array


### PR DESCRIPTION
This was a syntax mistake with the ad component setup. The size mapping needs to include arrays of sizes (which are also arrays) I think in the cases where there's only one size, the wrapping array is unnecessary, but i'd rather be consistent than concise here.