### PR TITLE
DS-342: Modify 'mediumAndUp' breakpoint to be minimum 769px

### DIFF
--- a/app/breakpoints.js
+++ b/app/breakpoints.js
@@ -10,7 +10,7 @@ export default {
   lessThanXsmall: `(max-width: ${xsmall - 1}px)`,
   xSmallAndUp: `(min-width: ${xsmall}px)`,
   smallAndUp: `(min-width: ${small}px)`,
-  mediumAndUp: `(min-width: ${medium}px)`,
+  mediumAndUp: `(min-width: ${medium + 1}px)`,
   largeAndUp: `(min-width: ${large}px)`,
   xLargeAndUp: `(min-width: ${xlarge}px)`,
   xxLargeAndUp: `(min-width: ${xxlarge}px)`,


### PR DESCRIPTION
https://jira.wnyc.org/browse/DS-342

Fixes an issue where the "share" module went vertical at exactly 768px width. This breakpoint, `mediumAndUp`, is only used here:

https://github.com/nypublicradio/gothamist-web-client/blob/11701e4c882d140aec41c27b0845a69d7dbbb321/app/templates/article/index.hbs#L31