### PR TITLE
Mwalsh/distinguish page views from slide views

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -22,7 +22,13 @@ export default Route.extend({
     this.router.on('routeWillChange', () => this.dataLayer.push({previousPath: this.router.currentURL}));
 
     // synthetic page view for analytics
-    this.router.on('routeDidChange', () => schedule('afterRender', () => this.dataLayer.sendPageView()));
+    this.router.on('routeDidChange', (transition) => {
+      if (transition.to === transition.from === 'article.gallery') {
+        schedule('afterRender', () => this.dataLayer.push('event', 'Gallery Slide View'));
+      } else {
+        schedule('afterRender', () => this.dataLayer.sendPageView());
+      }
+    });
   },
 
   title(tokens) {

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -2,6 +2,7 @@ import uuid from 'uuid/v1';
 import DS from 'ember-data';
 
 import Route from '@ember/routing/route';
+import { get } from '@ember/object';
 import { inject } from '@ember/service';
 import { schedule } from '@ember/runloop';
 import { doTargetingForPath, clearTargetingForPath } from 'nypr-ads';
@@ -23,7 +24,9 @@ export default Route.extend({
 
     // synthetic page view for analytics
     this.router.on('routeDidChange', (transition) => {
-      if (transition.to === transition.from === 'article.gallery') {
+      const from = get(transition, 'from.name')
+      const to = get(transition, 'to.name')
+      if (from === to === 'article.gallery') {
         schedule('afterRender', () => this.dataLayer.push('event', 'Gallery Slide View'));
       } else {
         schedule('afterRender', () => this.dataLayer.sendPageView());

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -27,10 +27,8 @@ export default Route.extend({
       const from = get(transition, 'from.name')
       const to = get(transition, 'to.name')
       if (from === 'article.gallery' && to === 'article.gallery') {
-        console.log('SLIDE VIEW');
         schedule('afterRender', () => this.dataLayer.push('event', 'Gallery Slide View'));
       } else {
-        console.log('PAGE VIEW');
         schedule('afterRender', () => this.dataLayer.sendPageView());
       }
     });

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -26,9 +26,11 @@ export default Route.extend({
     this.router.on('routeDidChange', (transition) => {
       const from = get(transition, 'from.name')
       const to = get(transition, 'to.name')
-      if (from === to === 'article.gallery') {
+      if (from === 'article.gallery' && to === 'article.gallery') {
+        console.log('SLIDE VIEW');
         schedule('afterRender', () => this.dataLayer.push('event', 'Gallery Slide View'));
       } else {
+        console.log('PAGE VIEW');
         schedule('afterRender', () => this.dataLayer.sendPageView());
       }
     });


### PR DESCRIPTION
When scrolling the Gallery, Send a 'Gallery Slide View' event instead of a synthetic 'Page View' event, In GTM, we still send both of these to GA as page views, but only refresh ads after the 'Page View' events.

This way ads don't refresh before our eyes while we're scrolling the gallery

This also depends on some updates to GTM:
https://tagmanager.google.com/#/container/accounts/602423278/containers/9295003/workspaces/22/tags