### PR TITLE
some post launch fixes

### DIFF
--- a/app/components/wnyc-block/template.hbs
+++ b/app/components/wnyc-block/template.hbs
@@ -1,6 +1,6 @@
 <NyprMBlock @orientation={{@orientation}} @size={{@size}} as |block|>
   <block.media
-    @url={{@story.url}}
+    @url={{concat @story.url '?utm_medium=partnersite&utm_source=gothamist&utm_campaign=homepagepromo'}}
     @srcS={{make-https this.thumbnail}}
     @alt={{@story.image-main.caption}}
   />
@@ -8,7 +8,7 @@
   <block.object as |o|>
     <o.title
       @h3
-      @url={{@story.url}}
+      @url={{concat @story.url '?utm_medium=partnersite&utm_source=gothamist&utm_campaign=homepagepromo'}}
     >
       {{@story.title}}
     </o.title>

--- a/app/models/article.js
+++ b/app/models/article.js
@@ -137,11 +137,11 @@ export default DS.Model.extend({
   }),
   isOpinion: computed('tags', function() {
     let tags = this.tags || [];
-    return tags.includes('@opinion');
+    return tags.includes('@opinion') || tags.includes('opinion');
   }),
   isAnalysis: computed('tags', function() {
     let tags = this.tags || [];
-    return tags.includes('@analysis');
+    return tags.includes('@analysis') || tags.includes('analysis');
   }),
 
   hasLead:          or('leadImage', 'hasGallery'),

--- a/app/routes/404.js
+++ b/app/routes/404.js
@@ -14,7 +14,7 @@ export default Route.extend({
   titleToken: '404 Error',
 
   model({ wildcard }) {
-    let match = wildcard.match(/http:\/\/gothamist.com\/(\d{4}\/\d{2}\/\d{2}\/[a-z_-].php)/);
+    let match = wildcard.match(/http:\/\/gothamist.com\/(\d{4}\/\d{2}\/\d{2}\/[a-z_-]+.php)/);
 
     if (match) {
       return this.transitionTo('article', match[0]);

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -122,6 +122,10 @@ $ember-basic-dropdown-content-z-index: 10000;
 }
 
 // ad layout
+.dfp-skin {
+  height: 0;
+}
+
 .break-margins {
   position: absolute;
   display: flex;
@@ -148,4 +152,3 @@ $ember-basic-dropdown-content-z-index: 10000;
 .break-margins.ad-height-600 + .space-filler {
   height: 600px;
 }
-

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,4 +1,4 @@
-<DfpAd role="presentation" aria-hidden="true" @slot='gothamist/skin' @sizes={{array (array 1 1)}} @clearOnEmptyRefresh={{true}} />
+<DfpAd class="dfp-skin" role="presentation" aria-hidden="true" @slot='gothamist/skin' @sizes={{array (array 1 1)}} @clearOnEmptyRefresh={{true}} />
 
 <HeadLayout/>
 


### PR DESCRIPTION
- add utm params to wnyc stories [DS-335](https://jira.wnyc.org/browse/DS-335)
- fix breadcrumb on on some opinion and analysis stories [DS-112](https://jira.wnyc.org/browse/DS-112)
- thin white line at top of screen (when ads are running; you can't test this until mei flights a takeover) [DS-348](https://jira.wnyc.org/browse/DS-348)