### PR TITLE
DS-372 Ad re-insertion

### DIFF
--- a/app/components/ad-tag-inside/component.js
+++ b/app/components/ad-tag-inside/component.js
@@ -1,7 +1,23 @@
+/* global googletag */
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
+import { run } from '@ember/runloop';
 
 export default Component.extend({
   tagName: '',
   fastboot: service(),
+  wormholeTarget: "",
+  actions: {
+    handleInsert(insertedTarget) {
+      this.set('wormholeDestination', insertedTarget);
+      if (this.ad && typeof(googletag) !== "undefined") {
+        run(() => {
+          googletag.pubads().refresh([this.ad]);
+        })
+      }
+    },
+    handleSlotRenderEnded(event) {
+      this.ad = event.slot;
+    },
+  }
 });

--- a/app/components/ad-tag-inside/component.js
+++ b/app/components/ad-tag-inside/component.js
@@ -1,7 +1,7 @@
 /* global googletag */
 import Component from '@ember/component';
 import { inject as service } from '@ember/service';
-import { run } from '@ember/runloop';
+import { next } from '@ember/runloop';
 
 export default Component.extend({
   tagName: '',
@@ -11,7 +11,7 @@ export default Component.extend({
     handleInsert(insertedTarget) {
       this.set('wormholeDestination', insertedTarget);
       if (this.ad && typeof(googletag) !== "undefined") {
-        run(() => {
+        next(() => {
           googletag.pubads().refresh([this.ad]);
         })
       }

--- a/app/components/ad-tag-inside/component.js
+++ b/app/components/ad-tag-inside/component.js
@@ -10,7 +10,7 @@ export default Component.extend({
   actions: {
     handleInsert(insertedTarget) {
       this.set('wormholeDestination', insertedTarget);
-      if (this.ad && typeof(googletag) !== "undefined") {
+      if (this.ad && typeof googletag !== "undefined") {
         next(() => {
           googletag.pubads().refresh([this.ad]);
         })

--- a/app/components/ad-tag-inside/template.hbs
+++ b/app/components/ad-tag-inside/template.hbs
@@ -2,6 +2,7 @@
   {{insert-target "inserted-ad"
     containerSelector=(or @containerSelector ".c-article__body")
   }}
+  data-test-inserted-ad
 >
   {{yield}}
 </div>

--- a/app/components/ad-tag-inside/template.hbs
+++ b/app/components/ad-tag-inside/template.hbs
@@ -2,7 +2,7 @@
   {{insert-target (or @contentsId "inserted-ad")
     containerSelector=(or @containerSelector ".c-article__body")
     contentsId=@contentsId
-    afterInsert=(action (action 'handleInsert'))
+    afterInsert=(action 'handleInsert')
   }}
   data-test-inserted-ad-wrapper
 >
@@ -21,7 +21,7 @@
       @slot={{@slot}}
       @breakMargins={{true}}
       @showLabel={{true}}
-      @slotRenderEndedAction={{action (action 'handleSlotRenderEnded')}}
+      @slotRenderEndedAction={{action 'handleSlotRenderEnded'}}
       data-test-inserted-ad
     />
   {{/ember-wormhole}}

--- a/app/components/ad-tag-inside/template.hbs
+++ b/app/components/ad-tag-inside/template.hbs
@@ -1,8 +1,9 @@
 <div
-  {{insert-target "inserted-ad"
+  {{insert-target (or @contentsId "inserted-ad")
     containerSelector=(or @containerSelector ".c-article__body")
+    contentsId=@contentsId
   }}
-  data-test-inserted-ad
+  data-test-inserted-ad-wrapper
 >
   {{yield}}
 </div>
@@ -14,11 +15,12 @@
   the DOM, we delay this until after fastboot.
 --}}
 {{#unless this.fastboot.isFastBoot}}
-  {{#ember-wormhole to="inserted-ad"}}
+  {{#ember-wormhole to=(or @contentsId "inserted-ad")}}
     <AdTagWide
       @slot={{@slot}}
       @breakMargins={{true}}
       @showLabel={{true}}
+      data-test-inserted-ad
     />
   {{/ember-wormhole}}
 {{/unless}}

--- a/app/components/ad-tag-inside/template.hbs
+++ b/app/components/ad-tag-inside/template.hbs
@@ -2,6 +2,7 @@
   {{insert-target (or @contentsId "inserted-ad")
     containerSelector=(or @containerSelector ".c-article__body")
     contentsId=@contentsId
+    afterInsert=(action (action 'handleInsert'))
   }}
   data-test-inserted-ad-wrapper
 >
@@ -14,13 +15,14 @@
   fastboot time. Since ad insertion requires
   the DOM, we delay this until after fastboot.
 --}}
-{{#unless this.fastboot.isFastBoot}}
-  {{#ember-wormhole to=(or @contentsId "inserted-ad")}}
+{{#if (and this.wormholeDestination (not this.fastboot.isFastBoot))}}
+  {{#ember-wormhole destinationElement=this.wormholeDestination}}
     <AdTagWide
       @slot={{@slot}}
       @breakMargins={{true}}
       @showLabel={{true}}
+      @slotRenderEndedAction={{action (action 'handleSlotRenderEnded')}}
       data-test-inserted-ad
     />
   {{/ember-wormhole}}
-{{/unless}}
+{{/if}}

--- a/app/components/ad-tag-wide/component.js
+++ b/app/components/ad-tag-wide/component.js
@@ -36,8 +36,8 @@ export default Component.extend({
       if (slot && slot.size) {
         this.set('height', slot.size[1]);
       }
-      if (this.attrs.slotRenderEndedAction) {
-        this.attrs.slotRenderEndedAction(slot);
+      if (this.get('slotRenderEndedAction')) {
+        this.get('slotRenderEndedAction')(slot);
       }
     }
   }

--- a/app/components/ad-tag-wide/component.js
+++ b/app/components/ad-tag-wide/component.js
@@ -24,11 +24,20 @@ export default Component.extend({
     @type {boolean}
   */
   breakMargins: false,
+  /**
+    Called when the dfp-ad finishes rendering
+
+    @argument handleSlotRenderEnded
+    @type {Function}
+  */
   height: 0,
   actions: {
     handleSlotRendered(slot) {
       if (slot && slot.size) {
         this.set('height', slot.size[1]);
+      }
+      if (this.attrs.slotRenderEndedAction) {
+        this.attrs.slotRenderEndedAction(slot);
       }
     }
   }

--- a/app/components/ad-tag-wide/component.js
+++ b/app/components/ad-tag-wide/component.js
@@ -27,8 +27,8 @@ export default Component.extend({
   /**
     Called when the dfp-ad finishes rendering
 
-    @argument handleSlotRenderEnded
-    @type {Function}
+    @argument slotRenderEndedAction
+    @type {function}
   */
   height: 0,
   actions: {

--- a/app/components/ad-tag-wide/component.js
+++ b/app/components/ad-tag-wide/component.js
@@ -36,8 +36,8 @@ export default Component.extend({
       if (slot && slot.size) {
         this.set('height', slot.size[1]);
       }
-      if (this.get('slotRenderEndedAction')) {
-        this.get('slotRenderEndedAction')(slot);
+      if (this.slotRenderEndedAction) {
+        this.slotRenderEndedAction(slot);
       }
     }
   }

--- a/app/modifiers/insert-target.js
+++ b/app/modifiers/insert-target.js
@@ -52,11 +52,9 @@ const InsertTargetModifier = Modifier.extend({
   },
 
   didReceiveArguments([id], {wordBoundary=150, containerSelector, classNames=[], contentsId='0'}) {
-    if(contentsId !== this.contentsId) {
-      this.contentsId = contentsId;
-      if (this.target && this.target.parentNode) {
-        this.target.parentNode.removeChild(this.target);
-      }
+    if (this.target && !this.target.parentNode) {
+    //   this.target.parentNode.removeChild(this.target);
+    // }
       this._insertDiv(id, {wordBoundary, containerSelector, classNames});
     }
 

--- a/app/modifiers/insert-target.js
+++ b/app/modifiers/insert-target.js
@@ -43,25 +43,32 @@ const InsertTargetModifier = Modifier.extend({
     @param  {String[]} [classNames=[]] A list of CSS classes
     to apply to the inserted div.
 
-    @param {String} [contentsId='0'] When this string changes
+    @param {String} [contentsId='0'] Whenever this string changes
     the div is removed and reinserted.
+
+    @param  {Function} [afterInsert] A callback that fires each time
+    the div is inserted successfully.
   */
-  didInsertElement([id], {wordBoundary=150, containerSelector, classNames=[], contentsId='0'}) {
-    this.contentsId = contentsId;
+  didInsertElement([id='inserted-target'], {wordBoundary=150, containerSelector, classNames=[], afterInsert, contentsId='0'}) {
     this._insertDiv(id, {wordBoundary, containerSelector, classNames});
+    if (afterInsert && this.target ) {
+      afterInsert(this.target );
+    }
+    this.contentsId = contentsId
   },
 
-  didReceiveArguments([id], {wordBoundary=150, containerSelector, classNames=[], contentsId='0'}) {
-    if (this.target && !this.target.parentNode) {
-    //   this.target.parentNode.removeChild(this.target);
-    // }
-      this._insertDiv(id, {wordBoundary, containerSelector, classNames});
+  didReceiveArguments([id='inserted-target'], {wordBoundary=150, containerSelector, classNames=[], afterInsert, contentsId='0'}) {
+    this._insertDiv(id, {wordBoundary, containerSelector, classNames});
+    if (afterInsert && this.target && contentsId !== this.contentsId) {
+      afterInsert(this.target);
     }
 
     if (classNames && this.target) {
       this.target.className = '';
       this.target.classList.add(...classNames);
     }
+
+    this.contentsId = contentsId;
   },
 
   _insertDiv(id, {wordBoundary, containerSelector, classNames}) {
@@ -91,15 +98,17 @@ const InsertTargetModifier = Modifier.extend({
         return node;
       }
     })
-    let target = document.createElement('div');
+    let target = this.target || document.createElement('div');
     this.target = target;
     target.id = id;
+    this.target.className = '';
     target.classList.add(...classNames)
     if (boundary && boundary.nextSibling) {
       container.insertBefore(target, boundary.nextSibling);
     } else {
       container.appendChild(target);
     }
+    return target;
   }
 });
 

--- a/app/modifiers/insert-target.js
+++ b/app/modifiers/insert-target.js
@@ -51,8 +51,8 @@ const InsertTargetModifier = Modifier.extend({
   */
   didInsertElement([id='inserted-target'], {wordBoundary=150, containerSelector, classNames=[], afterInsert, contentsId='0'}) {
     this._insertDiv(id, {wordBoundary, containerSelector, classNames});
-    if (afterInsert && this.target ) {
-      afterInsert(this.target );
+    if (afterInsert && this.target) {
+      afterInsert(this.target);
     }
     this.contentsId = contentsId
   },
@@ -99,15 +99,15 @@ const InsertTargetModifier = Modifier.extend({
       }
     })
     let target = this.target || document.createElement('div');
-    this.target = target;
     target.id = id;
-    this.target.className = '';
+    target.className = '';
     target.classList.add(...classNames)
     if (boundary && boundary.nextSibling) {
       container.insertBefore(target, boundary.nextSibling);
     } else {
       container.appendChild(target);
     }
+    this.target = target;
     return target;
   }
 });

--- a/app/modifiers/insert-target.js
+++ b/app/modifiers/insert-target.js
@@ -42,8 +42,31 @@ const InsertTargetModifier = Modifier.extend({
 
     @param  {String[]} [classNames=[]] A list of CSS classes
     to apply to the inserted div.
+
+    @param {String} [contentsId='0'] When this string changes
+    the div is removed and reinserted.
   */
-  didInsertElement([id], {wordBoundary=150, containerSelector, classNames=[]}) {
+  didInsertElement([id], {wordBoundary=150, containerSelector, classNames=[], contentsId='0'}) {
+    this.contentsId = contentsId;
+    this._insertDiv(id, {wordBoundary, containerSelector, classNames});
+  },
+
+  didReceiveArguments([id], {wordBoundary=150, containerSelector, classNames=[], contentsId='0'}) {
+    if(contentsId !== this.contentsId) {
+      this.contentsId = contentsId;
+      if (this.target && this.target.parentNode) {
+        this.target.parentNode.removeChild(this.target);
+      }
+      this._insertDiv(id, {wordBoundary, containerSelector, classNames});
+    }
+
+    if (classNames && this.target) {
+      this.target.className = '';
+      this.target.classList.add(...classNames);
+    }
+  },
+
+  _insertDiv(id, {wordBoundary, containerSelector, classNames}) {
     let container = document.querySelector(containerSelector) || this.element;
     let nodes = [...container.childNodes].filter(node => {
       // ignore whitespace only text and P nodes.
@@ -70,20 +93,14 @@ const InsertTargetModifier = Modifier.extend({
         return node;
       }
     })
-    let target = this.target = document.createElement('div');
+    let target = document.createElement('div');
+    this.target = target;
     target.id = id;
     target.classList.add(...classNames)
     if (boundary && boundary.nextSibling) {
       container.insertBefore(target, boundary.nextSibling);
     } else {
       container.appendChild(target);
-    }
-  },
-
-  didReceiveArguments(_,{classNames}) {
-    if (classNames) {
-      this.target.className = '';
-      this.target.classList.add(...classNames);
     }
   }
 });

--- a/app/templates/article/index.hbs
+++ b/app/templates/article/index.hbs
@@ -87,7 +87,7 @@
 
     </NyprOArticleHeader>
 
-    <AdTagInside @slot="gothamist/interior/midpage/1">
+    <AdTagInside @slot="gothamist/interior/midpage/1" @contentsId={{model.moveableTypeId}}>
       <NyprOArticleBody class={{unless model.hasLead 'u-space--zero--top'}} data-test-article-body>
         {{{model.body}}}
       </NyprOArticleBody>

--- a/tests/acceptance/article-test.js
+++ b/tests/acceptance/article-test.js
@@ -51,7 +51,7 @@ module('Acceptance | article', function(hooks) {
     assert.dom('[data-test-top-nav]').exists('nav should exist at load');
     assert.dom('[data-test-article-headline]').hasText(article.title);
     assert.dom('[data-test-article-body]').hasText(article.text);
-    assert.dom('[data-test-article-body] #inserted-ad').exists({count: 1})
+    assert.dom('[data-test-article-body] [data-test-inserted-ad]').exists({count: 1})
 
     // recirc
     assert.dom('[data-test-recirc-popular] .c-block').exists({count: 3});

--- a/tests/integration/components/ad-tag-inside/component-test.js
+++ b/tests/integration/components/ad-tag-inside/component-test.js
@@ -54,7 +54,7 @@ module('Integration | Component | ad-tag-inside', function(hooks) {
     assert.dom('.c-article__body #foo').exists()
     assert.dom('.c-article__body #foo [data-test-inserted-ad]').exists()
 
-    // this.element.querySelector('.c-article__body').innerHTML = `completely new article`;
+    this.element.querySelector('.c-article__body').innerHTML = `completely new article`;
     this.set('id', 'bar');
 
     await settled();

--- a/tests/integration/components/ad-tag-inside/component-test.js
+++ b/tests/integration/components/ad-tag-inside/component-test.js
@@ -1,6 +1,6 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
-import { render } from '@ember/test-helpers';
+import { render, settled } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
 
@@ -22,8 +22,8 @@ module('Integration | Component | ad-tag-inside', function(hooks) {
       {{/ad-tag-inside}}
     `);
 
-    assert.dom('.c-article__body #inserted-ad .ad-tag-wide').exists()
-    assert.dom('[data-test-inserted-ad]').exists()
+    assert.dom('[data-test-inserted-ad-wrapper]').exists()
+    assert.dom('.c-article__body #inserted-ad [data-test-inserted-ad]').exists()
   });
 
   test('it renders in the specified container', async function(assert) {
@@ -35,6 +35,7 @@ module('Integration | Component | ad-tag-inside', function(hooks) {
       {{/ad-tag-inside}}
     `);
 
+    assert.dom('[data-test-inserted-ad-wrapper]').exists()
     assert.dom('.special-div #inserted-ad .ad-tag-wide').exists()
     assert.dom('[data-test-inserted-ad]').exists()
   });
@@ -49,13 +50,16 @@ module('Integration | Component | ad-tag-inside', function(hooks) {
       {{/ad-tag-inside}}
     `);
 
-    assert.dom('.c-article__body #inserted-ad .ad-tag-wide').exists()
-    assert.dom('[data-test-inserted-ad]').exists()
+    assert.dom('[data-test-inserted-ad-wrapper]').exists()
+    assert.dom('.c-article__body #foo').exists()
+    assert.dom('.c-article__body #foo [data-test-inserted-ad]').exists()
 
-    this.element.querySelector('.c-article__body').innerHTML = `completely new article`;
+    // this.element.querySelector('.c-article__body').innerHTML = `completely new article`;
     this.set('id', 'bar');
 
-    assert.dom('.c-article__body #inserted-ad .ad-tag-wide').exists()
-    assert.dom('[data-test-inserted-ad]').exists()
+    await settled();
+
+    assert.dom('.c-article__body #bar').exists()
+    assert.dom('.c-article__body #bar [data-test-inserted-ad]').exists()
   });
 });

--- a/tests/integration/components/ad-tag-inside/component-test.js
+++ b/tests/integration/components/ad-tag-inside/component-test.js
@@ -23,7 +23,7 @@ module('Integration | Component | ad-tag-inside', function(hooks) {
     `);
 
     assert.dom('.c-article__body #inserted-ad .ad-tag-wide').exists()
-    assert.dom('[id^=ad_]').exists()
+    assert.dom('[data-test-inserted-ad]').exists()
   });
 
   test('it renders in the specified container', async function(assert) {
@@ -36,7 +36,26 @@ module('Integration | Component | ad-tag-inside', function(hooks) {
     `);
 
     assert.dom('.special-div #inserted-ad .ad-tag-wide').exists()
-    assert.dom('[id^=ad_]').exists()
+    assert.dom('[data-test-inserted-ad]').exists()
   });
 
+  test('it still has an ad after updating the contents', async function(assert) {
+    this.set('id','foo');
+    await render(hbs`
+      {{#ad-tag-inside contentsId=id}}
+        <div class='c-article__body'>
+          template block text
+        </div>
+      {{/ad-tag-inside}}
+    `);
+
+    assert.dom('.c-article__body #inserted-ad .ad-tag-wide').exists()
+    assert.dom('[data-test-inserted-ad]').exists()
+
+    this.element.querySelector('.c-article__body').innerHTML = `completely new article`;
+    this.set('id', 'bar');
+
+    assert.dom('.c-article__body #inserted-ad .ad-tag-wide').exists()
+    assert.dom('[data-test-inserted-ad]').exists()
+  });
 });

--- a/tests/integration/modifiers/insert-target-test.js
+++ b/tests/integration/modifiers/insert-target-test.js
@@ -140,17 +140,26 @@ module('Integration | Modifier | insert-target', function(hooks) {
     assert.deepEqual(elementList, ['p1','p2','trgt']);
   });
 
-  test('it should insert at the end if all else fails', async function(assert) {
-    await render(hbs`<div {{insert-target 'trgt' wordBoundary=100}}>
-      <h1 id="h1">{{this.oneHundredWords}}</h1>
-      <h2 id="h2">{{this.oneHundredWords}}</h2>
-      <h3 id="h3">{{this.oneHundredWords}}</h3>
-      <h4 id="h4">{{this.oneHundredWords}}</h4>
+  test('it should reinsert when the contentsId changes', async function(assert) {
+    this.set('id','foo');
+    await render(hbs`<div id="container" {{insert-target 'trgt' wordBoundary=300 contentsId=id}}>
       <p id="p1">{{this.oneHundredWords}}</p>
-      <iframe id="iframe"></iframe>
+      <p id="p2">{{this.oneHundredWords}}</p>
+      <p id="p3">{{this.oneHundredWords}}</p>
+      <p id="p4">{{this.oneHundredWords}}</p>
     </div>`);
     let elementList = [...this.element.firstChild.children].map(el => el.id);
     assert.dom('div#trgt').exists({count: 1});
-    assert.deepEqual(elementList, ['h1','h2','h3','h4','p1','iframe','trgt']);
+    assert.deepEqual(elementList, ['p1','p2','p3','trgt','p4']);
+
+    this.element.querySelector('#container').innerHTML =
+      `<p id="p5">${this.oneHundredWords}</p>` +
+      `<p id="p6">${this.oneHundredWords}</p>` +
+      `<p id="p7">${this.oneHundredWords}</p>` +
+      `<p id="p8">${this.oneHundredWords}</p>`;
+    this.set('id','bar');
+    elementList = [...this.element.firstChild.children].map(el => el.id);
+    assert.dom('div#trgt').exists({count: 1});
+    assert.deepEqual(elementList, ['p5','p6','p7','trgt','p8']);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4282,9 +4282,9 @@ electron-to-chromium@^1.3.124:
   integrity sha512-1o25iFRf/dbgauTWalEzmD1EmRN3a2CzP/K7UVpYLEBduk96LF0FyUdCcf4Ry2mAWJ1VxyblFjC93q6qlLwA2A==
 
 electron-to-chromium@^1.3.150, electron-to-chromium@^1.3.47:
-  version "1.3.159"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.159.tgz#4292643c5cb77678821ce01557ba6dd0f562db5e"
-  integrity sha512-bhiEr8/A97GUBcUzNb9MFNhzQOjakbKmEKBEAa6UMY45zG2e8PM63LOgAPXEJE9bQiaQH6nOdYiYf8X821tZjQ==
+  version "1.3.151"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.151.tgz#d4099131871ba2448706141162095ab977db805c"
+  integrity sha512-Lk5HHXw8hSGB6vYJO/yosy4U2JgVFoXn+uDMmZ0sYxltaKon5mKl2AbjNPkY+zBX9asnGDqEJzuzRq1t2aPm1Q==
 
 elliptic@^6.0.0:
   version "6.4.1"


### PR DESCRIPTION
https://jira.wnyc.org/browse/DS-372

This is starting to become a bit of a Rube Goldberg machine... I've been thinking about how to handle this if was starting from scratch but don't have any great ideas yet.

Anyway here's the sequence of events:

1. When navigating from one article to another, the new article loads and the `contentsId` (article id) sent to `insert-target` changes.
2. This triggers `didReceiveArguments` on the `insert-target` modifier, causing it to insert a div into the new article.
3. The `insert-target` modifier then calls the `afterInsert` action (`ad-tag-inside`'s `handleInsert`) with the inserted div.
4. In the `handleInsert` action the `ad-tag-inside` component, updates the wormhole target to the newly inserted div, causing the dfp-ad to be moved into the target div
5.  In the same `handleInsert` action, schedule the googletag API to refresh the ad.
