### PR TITLE
scrolling updates

### DIFF
--- a/app/components/disqus-comments/component.js
+++ b/app/components/disqus-comments/component.js
@@ -36,6 +36,9 @@ export default Component.extend({
         // we're the only ones controlling these callbacks
         // just replace it on every init
         this.callbacks.onReady = [onReady];
+      } else {
+        // it's preserved between renders so wipe it out
+        this.callbacks.onReady = [];
       }
     }
 

--- a/app/routes/404.js
+++ b/app/routes/404.js
@@ -49,6 +49,9 @@ export default Route.extend({
   actions: {
     didTransition() {
       schedule('afterRender', () => this.dataLayer.send404());
+      if (!this.fastboot.isFastBoot) {
+        window.scrollTo(0, 0);
+      }
       return true;
     }
   }

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -145,8 +145,6 @@ export default Route.extend({
     didTransition() {
       doTargetingForPath();
       if (typeof FastBoot === 'undefined') {
-        window.scrollTo(0, 0);
-
         this.metrics.trackPage()
       }
     },

--- a/app/templates/article/index.hbs
+++ b/app/templates/article/index.hbs
@@ -1,4 +1,5 @@
 <DoTargeting key='Template' value='Article' />
+{{remember-document-scroll key=model.id}}
 <div class="u-section-spacing l-container l-wrap">
   <article class="c-article l-container u-spacing--double">
     <NyprOArticleHeader as |header|>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,4 +1,5 @@
 {{set-body-class "homepage"}}
+{{remember-document-scroll key="homepage"}}
 <DoTargeting key='Template' value='Homepage' />
 
 <h1 class="is-vishidden" aria-hidden="true">Gothamist: New York City Local News, Food, Arts & Events</h1>

--- a/app/templates/sections.hbs
+++ b/app/templates/sections.hbs
@@ -1,3 +1,4 @@
+{{remember-document-scroll key=model.section}}
 <header class="c-section__header">
   <h1 class="c-section__heading u-font--secondary-style u-font--secondary" data-test-section-heading>
     {{model.title}}

--- a/app/templates/tags.hbs
+++ b/app/templates/tags.hbs
@@ -1,5 +1,5 @@
 <DoTargeting key='Template' value='Tag' />
-{{remember-document-scroll key=model.tag}}
+{{remember-document-scroll key=model.title}}
 
 <div class="c-listing__sections u-section-spacing l-container l-container--14col l-wrap">
   <header class="c-tag-listing__header u-trigger-floating-header">

--- a/app/templates/tags.hbs
+++ b/app/templates/tags.hbs
@@ -1,4 +1,6 @@
 <DoTargeting key='Template' value='Tag' />
+{{remember-document-scroll key=model.tag}}
+
 <div class="c-listing__sections u-section-spacing l-container l-container--14col l-wrap">
   <header class="c-tag-listing__header u-trigger-floating-header">
     <h1 class="c-tag-listing__heading u-font--secondary" data-test-tag-heading>

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "eslint-plugin-ember": "^5.2.0",
     "include-media": "^1.4.9",
     "loader.js": "^4.7.0",
+    "memory-scroll": "^0.9.1",
     "nypr-ads": "^1.1.1",
     "nypr-auth": "^0.2.4",
     "nypr-design-system": "^1.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8336,6 +8336,13 @@ memory-fs@^0.4.0, memory-fs@~0.4.1:
     errno "^0.1.3"
     readable-stream "^2.0.1"
 
+memory-scroll@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/memory-scroll/-/memory-scroll-0.9.1.tgz#d96871acf0b5f1a6c9662eeda3d7670f150d2415"
+  integrity sha512-aWn9W3BBSbqWyN+a+NS5FT6TeWTKtKMIg7W7P1QHKQZJU7NRDOYrOE4Z01uUsNDpNe3ez9JyoMuaCc21g6gSLQ==
+  dependencies:
+    ember-cli-babel "^6.8.2"
+
 memory-streams@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/memory-streams/-/memory-streams-0.1.3.tgz#d9b0017b4b87f1d92f55f2745c9caacb1dc93ceb"


### PR DESCRIPTION
[DS-380](https://jira.wnyc.org/browse/DS-380)

- adds `memory-scroll` addon to help manage scroll state between transitions
- blank out disqus onReady handler if onReady isn't passed in (otherwise it's still there and will call it anyway)