### PR TITLE
Integrated ad labels

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -5,5 +5,8 @@ module.exports = {
   rules: {
     quotes: false,
     'no-triple-curlies': false,
+    'no-inline-styles': {
+      allowDynamicStyles: true,
+    },
   }
 };

--- a/app/components/ad-tag-leaderboard/template.hbs
+++ b/app/components/ad-tag-leaderboard/template.hbs
@@ -26,4 +26,9 @@
     (array 970 90)
     (array 970 250)
   }}
-/>
+as |ad|>
+  {{ad.tag}}
+  {{#unless ad.isEmpty}}
+    <NyprAAdLabel/>
+  {{/unless}}
+</DfpAd>

--- a/app/components/ad-tag-tall/template.hbs
+++ b/app/components/ad-tag-tall/template.hbs
@@ -18,4 +18,9 @@
     (array 300 250)
     (array 300 600)
   }}
-/>
+as |ad|>
+  {{ad.tag}}
+  {{#unless ad.isEmpty}}
+    <NyprAAdLabel/>
+  {{/unless}}
+</DfpAd>

--- a/app/components/ad-tag-wide/component.js
+++ b/app/components/ad-tag-wide/component.js
@@ -30,12 +30,8 @@ export default Component.extend({
     @argument slotRenderEndedAction
     @type {function}
   */
-  height: 0,
   actions: {
     handleSlotRendered(slot) {
-      if (slot && slot.size) {
-        this.set('height', slot.size[1]);
-      }
       if (this.slotRenderEndedAction) {
         this.slotRenderEndedAction(slot);
       }

--- a/app/components/ad-tag-wide/template.hbs
+++ b/app/components/ad-tag-wide/template.hbs
@@ -44,6 +44,7 @@ as |ad|>
     </div>
   </div>
   {{#if (and @breakMargins (not ad.isEmpty))}}
-    <div class="space-filler" style="height: {{ad.height}}px"></div>
+    <div class="space-filler"
+    style={{html-safe (concat "height:" ad.height "px")}}></div>
   {{/if}}
 </DfpAd>

--- a/app/components/ad-tag-wide/template.hbs
+++ b/app/components/ad-tag-wide/template.hbs
@@ -1,48 +1,50 @@
-<div class="{{if @breakMargins "break-margins"}} {{concat "ad-height-" this.height}}">
-  <div class="flex-wrapper">
-    <DfpAd
-      @slot={{@slot}}
-      @target={{@target}}
-      @slotRenderEndedAction={{action 'handleSlotRendered'}}
-      @mapping={{array
-        (array 0
-          (array
-            (array 300 250)
-            (array 320 50)
-          )
-        )
-        (array 750
-          (array
-            (array 300 600)
-            (array 728 90)
-            (array 300 250)
-          )
-        )
-        (array 1000
-          (array
-            (array 970 250)
-            (array 970 90)
-            (array 728 90)
-            (array 300 600)
-            (array 300 250)
-          )
-        )
-      }}
-      @sizes={{array
-        (array 320 50)
+<DfpAd
+  @slot={{@slot}}
+  @target={{@target}}
+  @slotRenderEndedAction={{action 'handleSlotRendered'}}
+  @mapping={{array
+    (array 0
+      (array
         (array 300 250)
+        (array 320 50)
+      )
+    )
+    (array 750
+      (array
         (array 300 600)
         (array 728 90)
-        (array 970 90)
+        (array 300 250)
+      )
+    )
+    (array 1000
+      (array
         (array 970 250)
-      }}
-      data-test-ad-tag-wide
-    />
-    {{#if @showLabel}}
-      <NyprAAdLabel/>
-    {{/if}}
+        (array 970 90)
+        (array 728 90)
+        (array 300 600)
+        (array 300 250)
+      )
+    )
+  }}
+  @sizes={{array
+    (array 320 50)
+    (array 300 250)
+    (array 300 600)
+    (array 728 90)
+    (array 970 90)
+    (array 970 250)
+  }}
+  data-test-ad-tag-wide
+as |ad|>
+  <div class="{{if @breakMargins "break-margins"}}">
+    <div class="flex-wrapper">
+      {{ad.tag}}
+      {{#if (and @showLabel (not ad.isEmpty))}}
+        <NyprAAdLabel/>
+      {{/if}}
+    </div>
   </div>
-</div>
-{{#if @breakMargins}}
-  <div class="space-filler"></div>
-{{/if}}
+  {{#if @breakMargins}}
+    <div class="space-filler {{concat "height-" ad.height}}"></div>
+  {{/if}}
+</DfpAd>

--- a/app/components/ad-tag-wide/template.hbs
+++ b/app/components/ad-tag-wide/template.hbs
@@ -1,7 +1,6 @@
 <DfpAd
   @slot={{@slot}}
   @target={{@target}}
-  @slotRenderEndedAction={{action 'handleSlotRendered'}}
   @mapping={{array
     (array 0
       (array
@@ -36,7 +35,7 @@
   }}
   data-test-ad-tag-wide
 as |ad|>
-  <div class="{{if @breakMargins "break-margins"}}">
+  <div class={{if @breakMargins "break-margins"}}>
     <div class="flex-wrapper">
       {{ad.tag}}
       {{#if (and @showLabel (not ad.isEmpty))}}
@@ -44,7 +43,7 @@ as |ad|>
       {{/if}}
     </div>
   </div>
-  {{#if @breakMargins}}
-    <div class="space-filler {{concat "height-" ad.height}}"></div>
+  {{#if (and @breakMargins (not ad.isEmpty))}}
+    <div class="space-filler" style="height: {{ad.height}}px"></div>
   {{/if}}
 </DfpAd>

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -144,15 +144,15 @@ $ember-basic-dropdown-content-z-index: 10000;
 .ad-height-0 {
   display: none;
 }
-.break-margins.ad-height-50 + .space-filler {
+.space-filler.height-50 {
   height: 50px;
 }
-.break-margins.ad-height-90 + .space-filler {
+.space-filler.height-90  {
   height: 90px;
 }
-.break-margins.ad-height-250 + .space-filler {
+.space-filler.height-250 {
   height: 250px;
 }
-.break-margins.ad-height-600 + .space-filler {
+.space-filler.height-600 {
   height: 600px;
 }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -141,18 +141,3 @@ $ember-basic-dropdown-content-z-index: 10000;
 .space-filler {
   margin: 40px 0 32px 0;
 }
-.ad-height-0 {
-  display: none;
-}
-.space-filler.height-50 {
-  height: 50px;
-}
-.space-filler.height-90  {
-  height: 90px;
-}
-.space-filler.height-250 {
-  height: 250px;
-}
-.space-filler.height-600 {
-  height: 600px;
-}

--- a/app/templates/sections.hbs
+++ b/app/templates/sections.hbs
@@ -45,7 +45,6 @@
 
   <div class="c-listing__ad o-ad o-ad--billboard">
     <AdTagWide @slot="gothamist/interior/midpage/1" />
-    <NyprAAdLabel/>
   </div>
 
   <hr class="u-border-accent u-hide-until--m" aria-hidden="true">
@@ -88,7 +87,6 @@
 
         <div class="c-listing__ad o-ad o-ad--billboard">
           <AdTagWide @slot="gothamist/interior/midpage/repeating" />
-          <NyprAAdLabel/>
         </div>
 
         <hr class="u-border-accent u-hide-until--m" aria-hidden="true">

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "loader.js": "^4.7.0",
     "nypr-ads": "^1.1.1",
     "nypr-auth": "^0.2.4",
-    "nypr-design-system": "^1.0.7",
+    "nypr-design-system": "^1.0.8",
     "nypr-metrics": "^0.6.0",
     "qunit-dom": "^0.8.0",
     "sass": "^1.17.0",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "ember-sinon": "^3.1.0",
     "ember-sinon-qunit": "^3.4.0",
     "ember-source": "~3.9.0",
+    "ember-template-lint": "^1.2.0",
     "ember-test-selectors": "^2.0.0",
     "ember-truth-helpers": "^2.1.0",
     "ember-wormhole": "^0.5.5",
@@ -92,6 +93,9 @@
     "abortcontroller-polyfill": "^1.2.4",
     "dotenv": "^6.2.0",
     "nypr-fastboot": "^0.7.0"
+  },
+  "resolutions": {
+    "ember-template-lint": "^1.2.0"
   },
   "ember-addon": {
     "paths": [

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "eslint-plugin-ember": "^5.2.0",
     "include-media": "^1.4.9",
     "loader.js": "^4.7.0",
-    "nypr-ads": "^1.1.0",
+    "nypr-ads": "^1.1.1",
     "nypr-auth": "^0.2.4",
     "nypr-design-system": "^1.0.7",
     "nypr-metrics": "^0.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -751,15 +751,15 @@
     ember-cli-babel "^6.12.0"
     ember-cli-htmlbars-inline-precompile "^1.0.0"
 
-"@glimmer/compiler@^0.38.0":
-  version "0.38.4"
-  resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.38.4.tgz#ea5f39b9681a652dd96c48eeb55cd95aa6f6eddd"
-  integrity sha512-AQdDqInUM0yrUUEFdkNI2GR/WPfWN4HvbZYwgBet7TGicvfWXXLe76TI65H03SnPzoh835FDq2XcWLqlgwYt9w==
+"@glimmer/compiler@^0.38.5-alpha.1":
+  version "0.38.5-alpha.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.38.5-alpha.1.tgz#bd34a40d167c0bd589f8b9084adf49d771466747"
+  integrity sha512-PqliDQUQkwIDsxzFfSKsgQUkLk6/rQ5BaF2cSI5i6D8T1J+ZUgzT0NaHNiDCVWUSsqd+SDaFe/NjG3cP/dplVw==
   dependencies:
-    "@glimmer/interfaces" "^0.38.4"
-    "@glimmer/syntax" "^0.38.4"
-    "@glimmer/util" "^0.38.4"
-    "@glimmer/wire-format" "^0.38.4"
+    "@glimmer/interfaces" "^0.38.5-alpha.1"
+    "@glimmer/syntax" "^0.38.5-alpha.1"
+    "@glimmer/util" "^0.38.5-alpha.1"
+    "@glimmer/wire-format" "^0.38.5-alpha.1"
 
 "@glimmer/di@^0.2.0":
   version "0.2.1"
@@ -771,12 +771,12 @@
   resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
   integrity sha1-/S0rVakCnGs3psk16MiHGucN+gc=
 
-"@glimmer/interfaces@^0.38.4":
-  version "0.38.4"
-  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.38.4.tgz#437663eb07b97a22c8348a47b25191b5c5198bf3"
-  integrity sha512-Kuc2BNOZMnwmdZh3jOLUktVu9V0BASCRAslPmVfhzgPjD3j9VzqNOifD7eBz/ZvWqpS1e7CgBEc42CBlCBUfnQ==
+"@glimmer/interfaces@^0.38.5-alpha.1":
+  version "0.38.5-alpha.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.38.5-alpha.1.tgz#c1bbb7604c272fa879cd00dcbb9191efb22204a2"
+  integrity sha512-Q38UPwaIzTNgqh00fjf7BqMxtlHL2tchOqf3wKYWK0csfMhR+NvmWGVP02sr7vbXxw0+rf1hg9iv+Ejburbgqw==
   dependencies:
-    "@glimmer/wire-format" "^0.38.4"
+    "@glimmer/wire-format" "^0.38.5-alpha.1"
     "@simple-dom/interface" "1.4.0"
 
 "@glimmer/resolver@^0.4.1":
@@ -786,27 +786,27 @@
   dependencies:
     "@glimmer/di" "^0.2.0"
 
-"@glimmer/syntax@^0.38.4":
-  version "0.38.4"
-  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.38.4.tgz#eac34167cfa80daabb5db25fece1982c17a063f1"
-  integrity sha512-aB5vNC4ADCFXQWORFnx1kG8DtaWqS9E2zkynnj8/GqfYjO4yBtM0HFqBHAEIfcD8Zm+zK4osghs2YGrKvIsEdg==
+"@glimmer/syntax@^0.38.5-alpha.1":
+  version "0.38.5-alpha.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.38.5-alpha.1.tgz#5b2c13aff088a39c326e142b465c57e7e3cf8ba9"
+  integrity sha512-VB5mQFqL2A9y8Sx9spALarokyZRfRzgClsmX+K3J19N+oLuXu8al9+5T9utDTLDZy33PQzFMkDYf/x91n3w7ow==
   dependencies:
-    "@glimmer/interfaces" "^0.38.4"
-    "@glimmer/util" "^0.38.4"
+    "@glimmer/interfaces" "^0.38.5-alpha.1"
+    "@glimmer/util" "^0.38.5-alpha.1"
     handlebars "^4.0.6"
     simple-html-tokenizer "^0.5.6"
 
-"@glimmer/util@^0.38.4":
-  version "0.38.4"
-  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.38.4.tgz#43b4fbdf98c8c244ac7d1bfd95fef9c8f7761ad5"
-  integrity sha512-qFU96hAcDjK3ZD8lVJMB+FOJjCm+qZydiUICDj/CYTx82bSOfkzpHLNQ5OivJpsVl1+jFqJolQwrjqFC1bQJHA==
+"@glimmer/util@^0.38.5-alpha.1":
+  version "0.38.5-alpha.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.38.5-alpha.1.tgz#2508e5015ab3a42262bf608d885233115488148e"
+  integrity sha512-JO7PDInhp0FepIx1V6XTPJ4q1xPlNtdS3B8j0uteNnhOPpkIMbpRLcJKPJbAHuFRORQBEDEeWzkZ6NAPpfVenQ==
 
-"@glimmer/wire-format@^0.38.4":
-  version "0.38.4"
-  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.38.4.tgz#efbfe757b05e32344855b01804cc19dcca0d0828"
-  integrity sha512-1K8N+mbUtqJ1/MR+E/kDekC53HJNecU1i0TUAz5Vh24cvBcPCWP63YtwyCOxfnn7MLFdl8/QvHuo3+8Uxw+oVg==
+"@glimmer/wire-format@^0.38.5-alpha.1":
+  version "0.38.5-alpha.1"
+  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.38.5-alpha.1.tgz#f4b8476622cbe0b8cc0b0422677866d524aad2a1"
+  integrity sha512-BlgyY/11jaafWuK5DA13tvuwn1HOuso8MdW7PaFYqceFMYn/fhGrRXqcgeKiwT9p7U/LbNA1OZf678X2QYjzog==
   dependencies:
-    "@glimmer/util" "^0.38.4"
+    "@glimmer/util" "^0.38.5-alpha.1"
 
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
@@ -5390,12 +5390,12 @@ ember-source@~3.9.0:
     jquery "^3.3.1"
     resolve "^1.10.0"
 
-ember-template-lint@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/ember-template-lint/-/ember-template-lint-1.1.0.tgz#312e101728452bf082f54cbe429ed9b52273ba64"
-  integrity sha512-DPEWdjaNVIC58wJqeJStvQzk2gyKN5/u6dJfDKQ7mRJaouoLP1hZjSZwwpyO9bj10E9/3OJZnLmx1jjJ9/nqWA==
+ember-template-lint@^1.1.0, ember-template-lint@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/ember-template-lint/-/ember-template-lint-1.2.0.tgz#ae360e93cd225a936f6f9c7b66f39d71f8bdf1b8"
+  integrity sha512-kz+5YcmuP6dwxWUpOkanSGXkmPOP20MB7TXEngsa4zYV4Edo7yeHhWr756mj1MoZfFcxrRl1pS1CyqSmykdF9w==
   dependencies:
-    "@glimmer/compiler" "^0.38.0"
+    "@glimmer/compiler" "^0.38.5-alpha.1"
     chalk "^2.0.0"
     globby "^9.0.0"
     minimatch "^3.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8896,10 +8896,10 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
-nypr-ads@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/nypr-ads/-/nypr-ads-1.1.0.tgz#dd2a44486c7f2719c9a1278ef2c936c2eff15a81"
-  integrity sha512-HaCV8O/SwhF2ObXPHuxycS1e+GbebHYnkdoVQ9nL1qE4XIm8JJKPclaMOBVZk7F1dOMbRyTShRNlfQOZI/lA2g==
+nypr-ads@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/nypr-ads/-/nypr-ads-1.1.1.tgz#b1464bd2f673ca0a2882df637decc6258944c253"
+  integrity sha512-h6zsuqFoUMeuHryB6RUYQfgc3RW7FwJ36191Mol6sdV+w11ViHG4NWFjV6arcS8i66jCM8dHvROL1xZNo0swIg==
   dependencies:
     ember-cli-babel "^6.6.0"
     ember-cli-htmlbars "^2.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8913,11 +8913,12 @@ nypr-auth@^0.2.4:
     ember-get-config "^0.2.2"
     ember-simple-auth "^1.7.0"
 
-nypr-design-system@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/nypr-design-system/-/nypr-design-system-1.0.7.tgz#12b85727a388746087d1c12746eede010ddaa379"
-  integrity sha512-aGAH2beJHdscISdX1PDkTASRk5W48P/JjeivAYIfo+nK5HGHez6PSnBTKcAtcMgVrYfmI41fJ0yC+iaKSBOboQ==
+nypr-design-system@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/nypr-design-system/-/nypr-design-system-1.0.8.tgz#074fa5c988426da6cfd0a66766c4e136d5caa267"
+  integrity sha512-/3AuuL1BXEjRVlaM1/Ib/icT5vjP1GLe9YSNf1teqpNfj8N/uqYX9R8A8BhKIhzqlfrSg45tO5LaCeYkQ6wnzg==
   dependencies:
+    "@babel/core" "^7.0.0"
     broccoli-merge-files "^0.8.0"
     ember-auto-import "^1.2.19"
     ember-basic-dropdown "^1.1.2"


### PR DESCRIPTION
Depends on https://github.com/nypublicradio/nypr-ads/pull/9
Depends on https://github.com/nypublicradio/nypr-design-system/pull/16

Use the yielded values from the updated nypr-ads to build the components that represent our different ad tag configurations. We can use the isEmpty status to control whether or not we show the label.  Also remove the standalone label from the sections template.