### PR TITLE
chartbeat fixup

### DIFF
--- a/app/metrics-adapters/chartbeat.js
+++ b/app/metrics-adapters/chartbeat.js
@@ -47,6 +47,12 @@ export default BaseAdapter.extend({
   },
 
   trackPage(args) {
+    // chartbeat fires a pageview when the JS library loads
+    // so we skip our first call in order to prevent duplicate pageview reporting
+    if (!this._calledOnce) {
+      this._calledOnce = true;
+      return;
+    }
     let data = args.pageData || {};
 
     if (window && window.pSUPERFLY && window.pSUPERFLY.virtualPage) {

--- a/app/metrics-adapters/chartbeat.js
+++ b/app/metrics-adapters/chartbeat.js
@@ -47,12 +47,6 @@ export default BaseAdapter.extend({
   },
 
   trackPage(args) {
-    // chartbeat fires a pageview when the JS library loads
-    // so we skip our first call in order to prevent duplicate pageview reporting
-    if (!this._calledOnce) {
-      this._calledOnce = true;
-      return;
-    }
     let data = args.pageData || {};
 
     if (window && window.pSUPERFLY && window.pSUPERFLY.virtualPage) {

--- a/app/metrics-adapters/chartbeat.js
+++ b/app/metrics-adapters/chartbeat.js
@@ -60,7 +60,7 @@ export default BaseAdapter.extend({
         sections: derivedSection(data.sections),
         authors: derivedAuthors(data.authors),
         path: data.path,
-        title: data.title
+        title: document.title, // use whatever is in the title tag so we're in sync with ember-document-title
       });
     }
   },

--- a/app/metrics-adapters/chartbeat.js
+++ b/app/metrics-adapters/chartbeat.js
@@ -16,7 +16,7 @@ export default BaseAdapter.extend({
 
   init() {
     const config = get(this, "config") || {};
-    const { id, domain, section } = config;
+    const { id, domain, sections, authors } = config;
 
     if (canUseDOM) {
       /* eslint-disable */
@@ -29,9 +29,9 @@ export default BaseAdapter.extend({
         _sf_async_config.uid = id;
         _sf_async_config.flickerControl = false;
         _sf_async_config.useCanonical = true;
-        _sf_async_config.sections = derivedSection(section);
+        _sf_async_config.sections = derivedSection(sections);
         _sf_async_config.useCanonicalDomain = true;
-        _sf_async_config.authors = "";
+        _sf_async_config.authors = derivedAuthors(authors);
 
         function loadChartbeat() {
           var e = document.createElement("script");

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -83,7 +83,7 @@ export default Route.extend({
     }
   },
 
-  afterModel() {
+  afterModel(_model, transition) {
     if (this.fastboot.isFastBoot) {
       let { host, path } = this.fastboot.request;
       let url = `https://${host}${path.replace(/\/$/, '')}`;
@@ -97,15 +97,18 @@ export default Route.extend({
 
     // Lazy-load chartbeat
     if (!this.fastboot.isFastBoot) {
-      metrics.activateAdapters([
-        {
-          name: 'chartbeat',
-          environments: ['all'],
-          config: {
-            ...config.metrics.chartbeat,
+      transition.finally(() => {
+        metrics.activateAdapters([
+          {
+            name: 'chartbeat',
+            environments: ['all'],
+            config: {
+              ...config.metrics.chartbeat,
+              ...metrics.context.pageData,
+            }
           }
-        }
-      ]);
+        ]);
+      });
     }
 
   },

--- a/app/routes/article.js
+++ b/app/routes/article.js
@@ -53,7 +53,6 @@ export default Route.extend({
       this.set('metrics.context.pageData', {
         sections: model.section.label || model.section.basename,
         authors: model.authors,
-        title: model.title,
         path: window.path || model.path,
       })
     }

--- a/tests/acceptance/article-test.js
+++ b/tests/acceptance/article-test.js
@@ -269,4 +269,19 @@ module('Acceptance | article', function(hooks) {
       title: document.title,
     })
   });
+
+  test('chartbeat is initialized with article metadata on direct navigation', async function(assert) {
+    const SECTION = 'news';
+    const AUTHOR = 'Foo Bar';
+    server.create('article', {
+      categories: [{basename: SECTION}],
+      author_nickname: AUTHOR,
+      path: 'foo',
+    });
+
+    await visit('/foo');
+
+    assert.equal(window._sf_async_config.sections, "Gothamist,news,Gothamist news", 'should set section to article section');
+    assert.equal(window._sf_async_config.authors, "Foo Bar", 'should set author to article author');
+  });
 });

--- a/tests/acceptance/article-test.js
+++ b/tests/acceptance/article-test.js
@@ -263,7 +263,10 @@ module('Acceptance | article', function(hooks) {
       sections: `Gothamist,${article.categories[0].basename},Gothamist ${article.categories[0].basename}`,
       authors: article.author_nickname,
       path: article.path,
-      title: article.title
+
+      // chartbeat will use the <title> tag on initial load, so we need to use it manually so things stay in sync
+      // the document title is in sync with ember-cli-document-title
+      title: document.title,
     })
   });
 });

--- a/tests/acceptance/article-test.js
+++ b/tests/acceptance/article-test.js
@@ -237,15 +237,20 @@ module('Acceptance | article', function(hooks) {
     reset();
   });
 
-  test('chartbeat virtualPage is called', async function(assert) {
+  test('chartbeat virtualPage is called only once', async function(assert) {
     const article = server.create('article', {
       categories: [{basename: 'food'}],
     });
 
     const spy = this.spy(window.pSUPERFLY, 'virtualPage');
 
+    await visit('/');
+
+    await click('[data-test-block="1"] a'); // first article
+
     await visit(`/${article.path}`);
 
+    assert.ok(spy.calledOnce, 'should skip the first call because chartbeat triggers a pageview onload of the JS library');
     const spycall = spy.getCall(0)
 
     assert.deepEqual(Object.keys(spycall.args[0]), [


### PR DESCRIPTION
this PR addresses two issues:
- two pageviews fired on initial page load
- missing article metadata from chartbeat's automatic pageview event

so, chartbeat fires a pageview event when its JS library loads. because this fires out of sync with ember routing, it also lacks the correct metadata for when that automatic pageview is an article. 

This PR moves the chartbeat lazy-init into the application route's `transition#finally` callback, which allows us to include anything a child route may set on `metrics.context.pageData`, e.g. title, author and section.

The other side effect of moving init to `finally(...)` is that the chartbeat adapter is not actually initialized when `trackPage` is called in the application's very first `didTransition`, which prevents the duplicate pageviews. It *will* be initialized by the time any further navigation takes place.

Last bit: I changed the `virtualPage` call to use `document.title` so that whatever title is resolved by `ember-cli-document-title` is in sync with chartbeat