### PR TITLE
use new progress bar `target` argument on articles and galleries

### DIFF
--- a/app/routes/article/gallery.js
+++ b/app/routes/article/gallery.js
@@ -31,7 +31,7 @@ export default Route.extend({
       floating: {
         close: this.closeGallery.bind(this),
         share: true,
-        progressBar: true,
+        progressTarget: true,
         logoLinkClass: 'is-hiding-letters',
       }
     })

--- a/app/routes/article/index.js
+++ b/app/routes/article/index.js
@@ -35,7 +35,7 @@ export default Route.extend({
       },
       floating: {
         headline: model.title,
-        progressBar: true,
+        progressTarget: '.c-article__body',
         logoLinkClass: 'u-hide-until--m',
         share: {
           title: model.title,

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "loader.js": "^4.7.0",
     "nypr-ads": "^1.1.0",
     "nypr-auth": "^0.2.4",
-    "nypr-design-system": "^1.0.4",
+    "nypr-design-system": "nypublicradio/nypr-design-system#brian/ds-310",
     "nypr-metrics": "^0.6.0",
     "qunit-dom": "^0.8.0",
     "sass": "^1.17.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "loader.js": "^4.7.0",
     "nypr-ads": "^1.1.0",
     "nypr-auth": "^0.2.4",
-    "nypr-design-system": "nypublicradio/nypr-design-system#brian/ds-310",
+    "nypr-design-system": "^1.0.7",
     "nypr-metrics": "^0.6.0",
     "qunit-dom": "^0.8.0",
     "sass": "^1.17.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8913,9 +8913,10 @@ nypr-auth@^0.2.4:
     ember-get-config "^0.2.2"
     ember-simple-auth "^1.7.0"
 
-nypr-design-system@nypublicradio/nypr-design-system#brian/ds-310:
-  version "1.0.5"
-  resolved "https://codeload.github.com/nypublicradio/nypr-design-system/tar.gz/23f0fd3162717a3b0e3528281875e70c71904527"
+nypr-design-system@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/nypr-design-system/-/nypr-design-system-1.0.7.tgz#12b85727a388746087d1c12746eede010ddaa379"
+  integrity sha512-aGAH2beJHdscISdX1PDkTASRk5W48P/JjeivAYIfo+nK5HGHez6PSnBTKcAtcMgVrYfmI41fJ0yC+iaKSBOboQ==
   dependencies:
     broccoli-merge-files "^0.8.0"
     ember-auto-import "^1.2.19"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4282,9 +4282,9 @@ electron-to-chromium@^1.3.124:
   integrity sha512-1o25iFRf/dbgauTWalEzmD1EmRN3a2CzP/K7UVpYLEBduk96LF0FyUdCcf4Ry2mAWJ1VxyblFjC93q6qlLwA2A==
 
 electron-to-chromium@^1.3.150, electron-to-chromium@^1.3.47:
-  version "1.3.151"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.151.tgz#d4099131871ba2448706141162095ab977db805c"
-  integrity sha512-Lk5HHXw8hSGB6vYJO/yosy4U2JgVFoXn+uDMmZ0sYxltaKon5mKl2AbjNPkY+zBX9asnGDqEJzuzRq1t2aPm1Q==
+  version "1.3.159"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.159.tgz#4292643c5cb77678821ce01557ba6dd0f562db5e"
+  integrity sha512-bhiEr8/A97GUBcUzNb9MFNhzQOjakbKmEKBEAa6UMY45zG2e8PM63LOgAPXEJE9bQiaQH6nOdYiYf8X821tZjQ==
 
 elliptic@^6.0.0:
   version "6.4.1"
@@ -8913,10 +8913,9 @@ nypr-auth@^0.2.4:
     ember-get-config "^0.2.2"
     ember-simple-auth "^1.7.0"
 
-nypr-design-system@^1.0.4:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/nypr-design-system/-/nypr-design-system-1.0.6.tgz#6605c7251a5f793df13a15235d5cc64c46d62a58"
-  integrity sha512-ieNpmnlroEPJRUG/8DMcp81U66V7wQIEHjpavheGrDczgFBYOVvOG5h/AKUe52wGl8J1xR32yUc5Q/pX2bvO5w==
+nypr-design-system@nypublicradio/nypr-design-system#brian/ds-310:
+  version "1.0.5"
+  resolved "https://codeload.github.com/nypublicradio/nypr-design-system/tar.gz/23f0fd3162717a3b0e3528281875e70c71904527"
   dependencies:
     broccoli-merge-files "^0.8.0"
     ember-auto-import "^1.2.19"


### PR DESCRIPTION
`true` is passed in for galleries b/c as long as the argument is truthy,
then NyprOHeader will render the progress bar, and the truthy value
passed into progress bar will fall back to the `body` element, which
works fine for galleries

[DS-310](https://jira.wnyc.org/browse/DS-310)

depends on https://github.com/nypublicradio/nypr-design-system/pull/17