### PR TITLE
Use imgix to serve images

### DIFF
--- a/app/components/article-block/component.js
+++ b/app/components/article-block/component.js
@@ -3,7 +3,7 @@ import { computed } from '@ember/object';
 
 import config from '../../config/environment';
 import { medium } from '../../breakpoints';
-import { makeHttps } from '../../helpers/make-https';
+import { imgixUri } from '../../helpers/imgix-uri';
 
 
 const PATH = '/static-images/defaults';
@@ -28,7 +28,6 @@ export const FALLBACK_THUMBNAIL = {
     srcSet: `${PATH}/no-category/no-category-sq@2x.png 2x, ${PATH}/no-category/no-category-sq@3x.png 3x`,
     srcM: `${PATH}/no-category/no-category-tile.png 1x, ${PATH}/no-category/no-category-tile@2x.png 2x, ${PATH}/no-category/no-category-tile@3x.png 3x`
   },
-
 };
 
 export default Component.extend({
@@ -44,24 +43,30 @@ export default Component.extend({
     if (!this.article) {
       return;
     }
-    let srcS;
-    switch(this.thumbnailSize) {
-      case '640':
-        srcS = this.article.thumbnail640;
-        break;
-      case '105':
-        srcS = this.article.thumbnail105;
-        break;
-      default:
-        srcS = this.article.thumbnail300;
-    }
+    let path = this.article.thumbnailPath;
+    let [ w, h ] = this.thumbnailSize;
 
-    if (!srcS) {
+    if (path) {
+      let sizes = {
+        srcS: `${imgixUri(path, {w, h})}`,
+        srcSet: `${imgixUri(path, {w, h, dpr: 1})} 1x,
+        ${imgixUri(path, {w, h, dpr: 2})} 2x,
+        ${imgixUri(path, {w, h, dpr: 3})} 3x`,
+      };
+
+      if (this.mediumThumbnailSize) {
+        let [ w, h ] = this.mediumThumbnailSize;
+
+        sizes.srcM = `${imgixUri(path, {w, h, dpr: 1})} 1x,
+        ${imgixUri(path, {w, h, dpr: 2})} 2x,
+        ${imgixUri(path, {w, h, dpr: 3})} 3x`;
+      }
+
+      return sizes;
+    } else if (!path) {
       // fallback image
       let section = this.article.section || {};
       return FALLBACK_THUMBNAIL[section.basename];
-    } else {
-      return { srcS: makeHttps([ srcS ]) };
     }
   }),
 

--- a/app/components/article-block/component.js
+++ b/app/components/article-block/component.js
@@ -55,7 +55,10 @@ export default Component.extend({
 
     if (path) {
       let sizes = {
-        srcS: `${imgixUri(path, {w, h})}`,
+        srcS: `${imgixUri(path, {w, h, dpr: 1})}`,
+        srcSet: `${imgixUri(path, {w, h, dpr: 1})} 1x,
+        ${imgixUri(path, {w, h, dpr: 2})} 2x,
+        ${imgixUri(path, {w, h, dpr: 3})} 3x`,
       };
 
       if (this.mediumThumbnailSize) {

--- a/app/components/article-block/component.js
+++ b/app/components/article-block/component.js
@@ -56,17 +56,12 @@ export default Component.extend({
     if (path) {
       let sizes = {
         srcS: `${imgixUri(path, {w, h})}`,
-        srcSet: `${imgixUri(path, {w, h, dpr: 1})} 1x,
-        ${imgixUri(path, {w, h, dpr: 2})} 2x,
-        ${imgixUri(path, {w, h, dpr: 3})} 3x`,
       };
 
       if (this.mediumThumbnailSize) {
         let [ w, h ] = this.mediumThumbnailSize;
 
-        sizes.srcM = `${imgixUri(path, {w, h, dpr: 1})} 1x,
-        ${imgixUri(path, {w, h, dpr: 2})} 2x,
-        ${imgixUri(path, {w, h, dpr: 3})} 3x`;
+        sizes.srcM = `${imgixUri(path, {w, h})}`;
       }
 
       return sizes;

--- a/app/components/article-block/component.js
+++ b/app/components/article-block/component.js
@@ -39,6 +39,13 @@ export default Component.extend({
 
   commentsAnchor: config.commentsAnchor,
 
+  init() {
+    this._super(...arguments);
+    if (!this.thumbnailSize) {
+      this.thumbnailSize = [];
+    }
+  },
+
   thumbnail: computed('article', 'thumbnailSize', function() {
     if (!this.article) {
       return;

--- a/app/components/article-block/component.js
+++ b/app/components/article-block/component.js
@@ -51,20 +51,29 @@ export default Component.extend({
       return;
     }
     let path = this.article.thumbnailPath;
-    let [ w, h ] = this.thumbnailSize;
+    let [ w, h, highDpi ] = this.thumbnailSize;
 
     if (path) {
       let sizes = {
-        srcS: `${imgixUri(path, {w, h, dpr: 1})}`,
-        srcSet: `${imgixUri(path, {w, h, dpr: 1})} 1x,
-        ${imgixUri(path, {w, h, dpr: 2})} 2x,
-        ${imgixUri(path, {w, h, dpr: 3})} 3x`,
+        srcS: `${imgixUri(path, {w, h})}`,
       };
 
-      if (this.mediumThumbnailSize) {
-        let [ w, h ] = this.mediumThumbnailSize;
+      if (highDpi) {
+        sizes.srcSet = `${imgixUri(path, {w, h, dpr: 1})} 1x,
+          ${imgixUri(path, {w, h, dpr: 2})} 2x,
+          ${imgixUri(path, {w, h, dpr: 3})} 3x`;
+      }
 
-        sizes.srcM = `${imgixUri(path, {w, h})}`;
+      if (this.mediumThumbnailSize) {
+        let [ w, h, highDpi ] = this.mediumThumbnailSize;
+
+        if (highDpi) {
+          sizes.srcM = `${imgixUri(path, {w, h, dpr: 1})} 1x,
+          ${imgixUri(path, {w, h, dpr: 2})} 2x,
+          ${imgixUri(path, {w, h, dpr: 3})} 3x`;
+        } else {
+          sizes.srcM = `${imgixUri(path, {w, h})}`;
+        }
       }
 
       return sizes;

--- a/app/components/article-block/template.hbs
+++ b/app/components/article-block/template.hbs
@@ -5,9 +5,8 @@
     @srcSet={{this.thumbnail.srcSet}}
     @breakM={{this.thumbnailBreakpoint}}
     @srcM={{this.thumbnail.srcM}}
-    @alt={{or @article.leadImageAlt ""}}
-    @ratio={{@ratio}}
-    @ariaLabel={{unless @article.leadImageAlt @article.title}}
+    @alt=""
+    @ariaLabel={{@article.title}}
   />
 
   <block.object as |o|>

--- a/app/components/article-list/template.hbs
+++ b/app/components/article-list/template.hbs
@@ -4,7 +4,7 @@
       <ArticleBlock
         @article={{article}}
         @orientation={{if article.hasMain 'v' 'h'}}
-        @thumbnailSize={{if article.hasMain '640' '300'}}
+        @thumbnailSize={{if article.hasMain (array 640 0) (array 100 100)}}
       />
     </NyprMBlockList>
   </blg.col1>

--- a/app/components/article-list/template.hbs
+++ b/app/components/article-list/template.hbs
@@ -5,6 +5,7 @@
         @article={{article}}
         @orientation={{if article.hasMain 'v' 'h'}}
         @thumbnailSize={{if article.hasMain (array 640 0) (array 100 100)}}
+        @mediumThumbnailSize={{if article.hasMain (array 640 0) (array 150 150)}}
       />
     </NyprMBlockList>
   </blg.col1>

--- a/app/components/article-list/template.hbs
+++ b/app/components/article-list/template.hbs
@@ -4,8 +4,8 @@
       <ArticleBlock
         @article={{article}}
         @orientation={{if article.hasMain 'v' 'h'}}
-        @thumbnailSize={{if article.hasMain (array 640 0) (array 100 100)}}
-        @mediumThumbnailSize={{if article.hasMain (array 640 0) (array 150 150)}}
+        @thumbnailSize={{if article.hasMain (array 640 0) (array 100 100 true)}}
+        @mediumThumbnailSize={{if article.hasMain (array 640 0) (array 150 150 true)}}
       />
     </NyprMBlockList>
   </blg.col1>

--- a/app/components/article-recirc/template.hbs
+++ b/app/components/article-recirc/template.hbs
@@ -10,7 +10,7 @@
           @hideEyebrow={{true}}
           @article={{article}}
           @orientation='h'
-          @thumbnailSize='300'
+          @thumbnailSize={{array 100 100}}
           @hideExcerpt={{true}}
           @showAuthor={{true}}
           @showTimestamp={{false}}
@@ -28,7 +28,8 @@
         @hideEyebrow={{true}}
         @article={{featured.firstObject}}
         @orientation='v'
-        @thumbnailSize='640'
+        @thumbnailSize={{array 600 430}}
+        @mediumThumbnailSize={{array 378 252}}
         @showAuthor={{true}}
         @showTimestamp={{false}}
       />

--- a/app/components/article-recirc/template.hbs
+++ b/app/components/article-recirc/template.hbs
@@ -10,7 +10,7 @@
           @hideEyebrow={{true}}
           @article={{article}}
           @orientation='h'
-          @thumbnailSize={{array 100 100}}
+          @thumbnailSize={{array 100 100 true}}
           @hideExcerpt={{true}}
           @showAuthor={{true}}
           @showTimestamp={{false}}

--- a/app/helpers/imgix-uri.js
+++ b/app/helpers/imgix-uri.js
@@ -5,7 +5,6 @@ import config from '../config/environment';
 const DEFAULTS = {
   fit: 'crop',
   q: 75,
-  fm: 'webp',
 };
 
 export function imgixUri(path, ops = {}) {

--- a/app/helpers/imgix-uri.js
+++ b/app/helpers/imgix-uri.js
@@ -1,0 +1,32 @@
+import { helper } from '@ember/component/helper';
+
+import config from '../config/environment';
+
+const DEFAULTS = {
+  fit: 'crop',
+  q: 75,
+  fm: 'webp',
+};
+
+export function imgixUri(path, ops = {}) {
+  ops = {...DEFAULTS, ... ops};
+  let domain = config.imgixHost;
+
+  if (ops.domain === 'platypus') {
+    domain = config.imgixPlatypusHost;
+    delete ops.domain;
+  }
+
+  let qp = Object.keys(ops)
+    .filter(key => ops[key])
+    .map(key => `${key}=${ops[key]}`)
+    .join('&');
+
+  return `${domain}${path}${qp.length ? `?${qp}` : ''}`;
+}
+
+function makeHelper([ string ], hash) {
+  return imgixUri(string, hash);
+}
+
+export default helper(makeHelper);

--- a/app/helpers/imgix-uri.js
+++ b/app/helpers/imgix-uri.js
@@ -3,8 +3,10 @@ import { helper } from '@ember/component/helper';
 import config from '../config/environment';
 
 const DEFAULTS = {
+  crop: 'faces',
   fit: 'crop',
-  q: 75,
+  auto: 'compress,format', // content negotiation
+  fm: 'jpg',
 };
 
 export function imgixUri(path, ops = {}) {

--- a/app/index.html
+++ b/app/index.html
@@ -5,6 +5,11 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+
+    <link rel="preload" href="{{rootURL}}assets/vendor.js" as="script">
+    <link rel="preload" href="{{rootURL}}assets/gothamist-web-client.js" as="script">
+
     {{content-for "head"}}
 
     <!-- temporary design system css -->

--- a/app/models/article.js
+++ b/app/models/article.js
@@ -4,8 +4,8 @@ import DS from 'ember-data';
 import { computed } from '@ember/object';
 import { reads, or } from '@ember/object/computed';
 
-import { makeHttps } from '../helpers/make-https';
 import DomFixer from '../utils/dom-fixer';
+import { imgixUri } from '../helpers/imgix-uri';
 
 
 const GOTH_HOST_REGEX = /(https?:\/\/.*gothamist\.com)/;
@@ -232,6 +232,7 @@ export default DS.Model.extend({
     if (leadImage) {
       let img = leadImage.querySelector('img');
       parsed.leadImage = img ? img.src : '';
+      parsed.leadImage = imgixUri(parsed.leadImage.replace(GOTH_HOST_REGEX, ''), {w: 640, q: 90});
       parsed.leadImageLink = leadImageLink;
 
       let [, caption, credit] = this._getImageMeta(leadImage);

--- a/app/models/article.js
+++ b/app/models/article.js
@@ -70,7 +70,7 @@ export default DS.Model.extend({
           thumb: imgixUri(path, {w: 106, h: 106}),
           preview: imgixUri(path, {w: 625, h: 416, q: 90}),
           full: imgixUri(path, {w: 1200, q: 90}),
-          caption: this.galleryCaptions[i],
+          caption: DomFixer.removeHTML(this.galleryCaptions[i]),
           credit: this.galleryCredit[i],
           thumbSrcSet: `${imgixUri(path, {w: 106, h: 106, dpr: 1})} 1x,
           ${imgixUri(path, {w: 106, h: 106, dpr: 2})} 2x,
@@ -243,7 +243,7 @@ export default DS.Model.extend({
       let [, caption, credit] = this._getImageMeta(leadImage);
       parsed.caption = caption ? caption.trim() : 'Image from Gothamist';
       parsed.credit = credit ? credit.trim() : '';
-      parsed.alt = caption? domFixer.removeHTML(parsed.caption) : "";
+      parsed.alt = caption? DomFixer.removeHTML(parsed.caption) : "";
     }
 
     parsed.nodes = domFixer.nodes;

--- a/app/models/article.js
+++ b/app/models/article.js
@@ -65,9 +65,11 @@ export default DS.Model.extend({
     } else {
       let slides = [];
       for (let i = 0; i < this.galleryFull.length; i++) {
+        let path = this.galleryFull[i].replace(GOTH_HOST_REGEX, '');
         slides.push({
-          full: makeHttps([this.galleryFull[i]]),
-          thumb: makeHttps([this.galleryArray[i]]),
+          thumb: imgixUri(path, {w: 106, h: 106}),
+          preview: imgixUri(path, {w: 625, h: 416, q: 90}),
+          full: imgixUri(path, {w: 1200, q: 90}),
           caption: this.galleryCaptions[i],
           credit: this.galleryCredit[i],
         });

--- a/app/models/article.js
+++ b/app/models/article.js
@@ -96,6 +96,7 @@ export default DS.Model.extend({
     } else if (this.thumbnail60) {
       thumbnail = this.thumbnail60;
     } else {
+      // no thumbnail for this article
       return;
     }
     return thumbnail.replace(GOTH_HOST_REGEX, '');
@@ -236,8 +237,7 @@ export default DS.Model.extend({
     // extract caption and credit and alt
     if (leadImage) {
       let img = leadImage.querySelector('img');
-      parsed.leadImage = img ? img.src : '';
-      parsed.leadImage = imgixUri(parsed.leadImage.replace(GOTH_HOST_REGEX, ''), {w: 640, q: 90});
+      parsed.leadImage = img ? imgixUri(img.src.replace(GOTH_HOST_REGEX, ''), {w: 640, q: 90}) : '';
       parsed.leadImageLink = leadImageLink;
 
       let [, caption, credit] = this._getImageMeta(leadImage);

--- a/app/models/article.js
+++ b/app/models/article.js
@@ -7,6 +7,9 @@ import { reads, or } from '@ember/object/computed';
 import { makeHttps } from '../helpers/make-https';
 import DomFixer from '../utils/dom-fixer';
 
+
+const GOTH_HOST_REGEX = /(https?:\/\/.*gothamist\.com)/;
+
 export default DS.Model.extend({
   allowComments: DS.attr('boolean'),
   authorId: DS.attr('number'),
@@ -77,6 +80,21 @@ export default DS.Model.extend({
 
 
   // computed
+  thumbnailPath: computed('{thumbnail640,thumbnail300,thumbnail105,thumbnail60}', function() {
+    let thumbnail;
+    if (this.thumbnail640) {
+      thumbnail = this.thumbnail640;
+    } else if (this.thumbnail300) {
+      thumbnail = this.thumbnail300;
+    } else if (this.thumbnail105) {
+      thumbnail = this.thumbnail105;
+    } else if (this.thumbnail60) {
+      thumbnail = this.thumbnail60;
+    } else {
+      return;
+    }
+    return thumbnail.replace(GOTH_HOST_REGEX, '');
+  }),
   path: computed('permalink', function() {
     return this.permalink.replace('http://gothamist.com/', '');
   }),

--- a/app/models/article.js
+++ b/app/models/article.js
@@ -72,6 +72,9 @@ export default DS.Model.extend({
           full: imgixUri(path, {w: 1200, q: 90}),
           caption: this.galleryCaptions[i],
           credit: this.galleryCredit[i],
+          thumbSrcSet: `${imgixUri(path, {w: 106, h: 106, dpr: 1})} 1x,
+          ${imgixUri(path, {w: 106, h: 106, dpr: 2})} 2x,
+          ${imgixUri(path, {w: 106, h: 106, dpr: 3})} 3x`,
         });
       }
       this.set('gallery', {slides});

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -90,6 +90,7 @@ export default Route.extend({
 
       this.headData.setProperties({
         url,
+        apiServer: config.apiServer,
       });
     }
 

--- a/app/serializers/gallery.js
+++ b/app/serializers/gallery.js
@@ -26,6 +26,9 @@ export default DS.RESTSerializer.extend({
         height: (RESIZED_WIDTH / RATIO),
         caption: item.caption,
         credit: payload.gallery.photographer,
+        thumbSrcSet: `${imgixUri(path, {w: 106, h: 106, dpr: 1, domain: 'platypus'})} 1x,
+        ${imgixUri(path, {w: 106, h: 106, dpr: 2, domain: 'platypus'})} 2x,
+        ${imgixUri(path, {w: 106, h: 106, dpr: 3, domain: 'platypus'})} 3x`,
       });
     });
     return {data: gallery};

--- a/app/serializers/gallery.js
+++ b/app/serializers/gallery.js
@@ -1,5 +1,9 @@
 import DS from 'ember-data';
-import { makeHttps } from '../helpers/make-https';
+
+import { imgixUri } from '../helpers/imgix-uri';
+
+const GOTH_HOST_REGEX = /(https?:\/\/.*gothamist\.com)/;
+
 
 export default DS.RESTSerializer.extend({
   normalizeFindRecordResponse(store, galleryClass, payload, id) {
@@ -12,11 +16,14 @@ export default DS.RESTSerializer.extend({
       }
     };
     payload.gallery.items.forEach(item => {
+      const RATIO = item.img_web_width / item.img_web_height;
+      const RESIZED_WIDTH = 1200;
+      let path = item.img_web_gallery.replace(GOTH_HOST_REGEX, '');
       slides.push({
-        thumb: makeHttps([item.img_square]),
-        full: makeHttps([item.img_web_gallery]),
-        width: item.img_web_width,
-        height: item.img_web_height,
+        thumb: imgixUri(path, {w: 106, h: 106, domain: 'platypus'}),
+        preview: imgixUri(path, {w: 625, h: 416, q: 90, domain: 'platypus'}),
+        full: imgixUri(path, {w: RESIZED_WIDTH, q: 90, domain: 'platypus'}),
+        height: (RESIZED_WIDTH / RATIO),
         caption: item.caption,
         credit: payload.gallery.photographer,
       });

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,6 +1,3 @@
-// CSS imports
-@import url('https://fonts.googleapis.com/css?family=Lato:400,400i,700&display=optional');
-
 // third party imports
 $ember-basic-dropdown-content-z-index: 10000;
 @import "ember-basic-dropdown";

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -92,7 +92,9 @@ $ember-basic-dropdown-content-z-index: 10000;
 }
 
 .is-hiding-letters .gothamist-logo-icon .letters {
-  display: none;
+  @media only screen and (max-width: 768px) {
+    display: none;
+  }
 }
 
 // improve side menu scrolling

--- a/app/templates/404.hbs
+++ b/app/templates/404.hbs
@@ -35,7 +35,7 @@
           <ArticleBlock
             @article={{article}}
             @orientation='h'
-            @thumbnailSize='300'
+            @thumbnailSize={{array 100 100}}
             @hideExcerpt={{true}}
           />
         </NyprMBlockList>

--- a/app/templates/404.hbs
+++ b/app/templates/404.hbs
@@ -35,7 +35,7 @@
           <ArticleBlock
             @article={{article}}
             @orientation='h'
-            @thumbnailSize={{array 100 100}}
+            @thumbnailSize={{array 150 150 true}}
             @hideExcerpt={{true}}
           />
         </NyprMBlockList>

--- a/app/templates/500.hbs
+++ b/app/templates/500.hbs
@@ -35,7 +35,7 @@
           <ArticleBlock
             @article={{article}}
             @orientation='h'
-            @thumbnailSize='300'
+            @thumbnailSize={{array 100 100}}
             @hideExcerpt={{true}}
           />
         </NyprMBlockList>

--- a/app/templates/500.hbs
+++ b/app/templates/500.hbs
@@ -35,7 +35,7 @@
           <ArticleBlock
             @article={{article}}
             @orientation='h'
-            @thumbnailSize={{array 100 100}}
+            @thumbnailSize={{array 150 150 true}}
             @hideExcerpt={{true}}
           />
         </NyprMBlockList>

--- a/app/templates/author-detail.hbs
+++ b/app/templates/author-detail.hbs
@@ -20,7 +20,8 @@
           @article={{article}}
           @orientation='h'
           @size='l'
-          @thumbnailSize='300'
+          @thumbnailSize={{array 100 100}}
+          @mediumThumbnailSize={{array 360 240}}
         />
       </NyprMBlockList>
     </section>
@@ -31,7 +32,8 @@
           @article={{article}}
           @orientation='h'
           @size='l'
-          @thumbnailSize='300'
+          @thumbnailSize={{array 100 100}}
+          @mediumThumbnailSize={{array 360 240}}
         />
       </NyprMBlockList>
     </section>
@@ -50,7 +52,8 @@
                 @article={{article}}
                 @orientation='h'
                 @size='l'
-                @thumbnailSize='300'
+                @thumbnailSize={{array 100 100}}
+                @mediumThumbnailSize={{array 360 240}}
               />
             </NyprMBlockList>
           </section>
@@ -61,7 +64,8 @@
                 @article={{article}}
                 @orientation='h'
                 @size='l'
-                @thumbnailSize='300'
+                @thumbnailSize={{array 100 100}}
+                @mediumThumbnailSize={{array 360 240}}
               />
             </NyprMBlockList>
           </section>

--- a/app/templates/author-detail.hbs
+++ b/app/templates/author-detail.hbs
@@ -20,7 +20,7 @@
           @article={{article}}
           @orientation='h'
           @size='l'
-          @thumbnailSize={{array 100 100}}
+          @thumbnailSize={{array 100 100 true}}
           @mediumThumbnailSize={{array 360 240}}
         />
       </NyprMBlockList>
@@ -32,7 +32,7 @@
           @article={{article}}
           @orientation='h'
           @size='l'
-          @thumbnailSize={{array 100 100}}
+          @thumbnailSize={{array 100 100 true}}
           @mediumThumbnailSize={{array 360 240}}
         />
       </NyprMBlockList>
@@ -52,7 +52,7 @@
                 @article={{article}}
                 @orientation='h'
                 @size='l'
-                @thumbnailSize={{array 100 100}}
+                @thumbnailSize={{array 100 100 true}}
                 @mediumThumbnailSize={{array 360 240}}
               />
             </NyprMBlockList>
@@ -64,7 +64,7 @@
                 @article={{article}}
                 @orientation='h'
                 @size='l'
-                @thumbnailSize={{array 100 100}}
+                @thumbnailSize={{array 100 100 true}}
                 @mediumThumbnailSize={{array 360 240}}
               />
             </NyprMBlockList>

--- a/app/templates/head.hbs
+++ b/app/templates/head.hbs
@@ -1,4 +1,5 @@
-
+<link rel="preconnect" href={{model.apiServer}} crossorigin>
+<link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
 {{#if model.ampId}}
   <link rel="amphtml" href="https://amp.gothamist.com/amp/articles/create?article_id={{model.ampId}}">
 {{/if}}
@@ -12,6 +13,8 @@
 <meta property="og:site_name" content="Gothamist">
 
 {{#if model.image}}
+  <link rel="preload" as="image" href={{model.image.full}}>
+
   <meta property="og:image" content={{model.image.full}}>
   <meta property="twitter:image" content={{model.image.full}}>
 
@@ -45,6 +48,7 @@
 {{/if}}
 
 {{#each model.gallery as |slide|}}
+  <link rel="preload" as="image" href={{slide.full}}>
   <meta property="og:image" content={{slide.full}}>
   <meta property="og:image:width" content={{slide.width}}>
   <meta property="og:image:height" content={{slide.height}}>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -26,7 +26,7 @@
           @article={{item}}
           @orientation='h'
           @size='s'
-          @thumbnailSize={{array 100 100}}
+          @thumbnailSize={{array 100 100 true}}
           @mediumThumbnailSize={{array 150 150}}
           @hideExcerpt={{true}}
         />
@@ -38,7 +38,7 @@
   {{#if model.sponsored}}
     <div class="l-container l-container--16col">
       <NyprOSponsoredTout @heading="Sponsored" data-test-sponsored-tout>
-        <ArticleBlock @article={{model.sponsored.firstObject}} @thumbnailSize={{array 328 219}}/>
+        <ArticleBlock @article={{model.sponsored.firstObject}} @thumbnailSize={{array 328 219 true}}/>
       </NyprOSponsoredTout>
     </div>
   {{/if}}

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -27,6 +27,7 @@
           @orientation='h'
           @size='s'
           @thumbnailSize={{array 100 100}}
+          @mediumThumbnailSize={{array 150 150}}
           @hideExcerpt={{true}}
         />
       </NyprMBlockList>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -16,7 +16,7 @@
 
     <fbl.featured>
       {{#with model.main.firstObject as |article|}}
-        <ArticleBlock @article={{article}} @thumbnailSize='640'/>
+        <ArticleBlock @article={{article}} @thumbnailSize={{array 800 533}}/>
       {{/with}}
     </fbl.featured>
 
@@ -26,7 +26,7 @@
           @article={{item}}
           @orientation='h'
           @size='s'
-          @thumbnailSize='300'
+          @thumbnailSize={{array 100 100}}
           @hideExcerpt={{true}}
         />
       </NyprMBlockList>
@@ -37,7 +37,7 @@
   {{#if model.sponsored}}
     <div class="l-container l-container--16col">
       <NyprOSponsoredTout @heading="Sponsored" data-test-sponsored-tout>
-        <ArticleBlock @article={{model.sponsored.firstObject}} @thumbnailSize='640'/>
+        <ArticleBlock @article={{model.sponsored.firstObject}} @thumbnailSize={{array 328 219}}/>
       </NyprOSponsoredTout>
     </div>
   {{/if}}

--- a/app/templates/sections.hbs
+++ b/app/templates/sections.hbs
@@ -11,9 +11,8 @@
       <ArticleBlock
         @article={{object-at 0 model.articles}}
         @orientation='v'
-        @thumbnailSize='640'
+        @thumbnailSize={{array 800 533}}
         @hideEyebrow={{true}}
-        @ratio='3x2'
       />
     </blg.col1>
 
@@ -21,9 +20,8 @@
       <ArticleBlock
         @article={{object-at 1 model.articles}}
         @orientation='v'
-        @thumbnailSize='640'
+        @thumbnailSize={{array 800 533}}
         @hideEyebrow={{true}}
-        @ratio='3x2'
       />
     </blg.col2>
   </NyprOBlockListGroup>
@@ -36,7 +34,8 @@
         @article={{article}}
         @orientation='h'
         @size='l'
-        @thumbnailSize='300'
+        @thumbnailSize={{array 100 100}}
+        @mediumThumbnailSize={{array 360 240}}
         @hideEyebrow={{true}}
       />
     </NyprMBlockList>
@@ -56,7 +55,8 @@
         @article={{article}}
         @orientation='h'
         @size='l'
-        @thumbnailSize='300'
+        @thumbnailSize={{array 100 100}}
+        @mediumThumbnailSize={{array 360 240}}
         @hideEyebrow={{true}}
       />
     </NyprMBlockList>
@@ -78,7 +78,8 @@
               @article={{article}}
               @orientation='h'
               @size='l'
-              @thumbnailSize='300'
+              @thumbnailSize={{array 100 100}}
+              @mediumThumbnailSize={{array 360 240}}
               @hideEyebrow={{true}}
             />
           </NyprMBlockList>
@@ -98,7 +99,8 @@
               @article={{article}}
               @orientation='h'
               @size='l'
-              @thumbnailSize='300'
+              @thumbnailSize={{array 100 100}}
+              @mediumThumbnailSize={{array 360 240}}
               @hideEyebrow={{true}}
             />
           </NyprMBlockList>

--- a/app/templates/sections.hbs
+++ b/app/templates/sections.hbs
@@ -34,7 +34,7 @@
         @article={{article}}
         @orientation='h'
         @size='l'
-        @thumbnailSize={{array 100 100}}
+        @thumbnailSize={{array 100 100 true}}
         @mediumThumbnailSize={{array 360 240}}
         @hideEyebrow={{true}}
       />
@@ -55,7 +55,7 @@
         @article={{article}}
         @orientation='h'
         @size='l'
-        @thumbnailSize={{array 100 100}}
+        @thumbnailSize={{array 100 100 true}}
         @mediumThumbnailSize={{array 360 240}}
         @hideEyebrow={{true}}
       />
@@ -78,7 +78,7 @@
               @article={{article}}
               @orientation='h'
               @size='l'
-              @thumbnailSize={{array 100 100}}
+              @thumbnailSize={{array 100 100 true}}
               @mediumThumbnailSize={{array 360 240}}
               @hideEyebrow={{true}}
             />
@@ -99,7 +99,7 @@
               @article={{article}}
               @orientation='h'
               @size='l'
-              @thumbnailSize={{array 100 100}}
+              @thumbnailSize={{array 100 100 true}}
               @mediumThumbnailSize={{array 360 240}}
               @hideEyebrow={{true}}
             />

--- a/app/templates/tags.hbs
+++ b/app/templates/tags.hbs
@@ -17,7 +17,7 @@
           @article={{article}}
           @orientation='h'
           @size='l'
-          @thumbnailSize={{array 100 100}}
+          @thumbnailSize={{array 100 100 true}}
           @mediumThumbnailSize={{array 360 240}}
         />
       </NyprMBlockList>
@@ -48,7 +48,7 @@
           @article={{article}}
           @orientation='h'
           @size='l'
-          @thumbnailSize={{array 100 100}}
+          @thumbnailSize={{array 100 100 true}}
           @mediumThumbnailSize={{array 360 240}}
         />
       </NyprMBlockList>
@@ -61,7 +61,7 @@
           @article={{article}}
           @orientation='h'
           @size='l'
-          @thumbnailSize={{array 100 100}}
+          @thumbnailSize={{array 100 100 true}}
           @mediumThumbnailSize={{array 360 240}}
         />
       </NyprMBlockList>
@@ -83,7 +83,7 @@
         @article={{article}}
         @orientation='h'
         @size='l'
-        @thumbnailSize={{array 100 100}}
+        @thumbnailSize={{array 100 100 true}}
         @mediumThumbnailSize={{array 360 240}}
       />
     </NyprMBlockList>
@@ -104,7 +104,7 @@
               @article={{article}}
               @orientation='h'
               @size='l'
-              @thumbnailSize={{array 100 100}}
+              @thumbnailSize={{array 100 100 true}}
               @mediumThumbnailSize={{array 360 240}}
             />
           </NyprMBlockList>
@@ -125,7 +125,7 @@
               @article={{article}}
               @orientation='h'
               @size='l'
-              @thumbnailSize={{array 100 100}}
+              @thumbnailSize={{array 100 100 true}}
               @mediumThumbnailSize={{array 360 240}}
             />
           </NyprMBlockList>

--- a/app/templates/tags.hbs
+++ b/app/templates/tags.hbs
@@ -17,7 +17,8 @@
           @article={{article}}
           @orientation='h'
           @size='l'
-          @thumbnailSize='300'
+          @thumbnailSize={{array 100 100}}
+          @mediumThumbnailSize={{array 360 240}}
         />
       </NyprMBlockList>
     </section>
@@ -47,7 +48,8 @@
           @article={{article}}
           @orientation='h'
           @size='l'
-          @thumbnailSize='300'
+          @thumbnailSize={{array 100 100}}
+          @mediumThumbnailSize={{array 360 240}}
         />
       </NyprMBlockList>
     </section>
@@ -59,7 +61,8 @@
           @article={{article}}
           @orientation='h'
           @size='l'
-          @thumbnailSize='300'
+          @thumbnailSize={{array 100 100}}
+          @mediumThumbnailSize={{array 360 240}}
         />
       </NyprMBlockList>
     </section>
@@ -80,7 +83,8 @@
         @article={{article}}
         @orientation='h'
         @size='l'
-        @thumbnailSize='300'
+        @thumbnailSize={{array 100 100}}
+        @mediumThumbnailSize={{array 360 240}}
       />
     </NyprMBlockList>
   </section>
@@ -100,7 +104,8 @@
               @article={{article}}
               @orientation='h'
               @size='l'
-              @thumbnailSize='300'
+              @thumbnailSize={{array 100 100}}
+              @mediumThumbnailSize={{array 360 240}}
             />
           </NyprMBlockList>
         </section>
@@ -120,7 +125,8 @@
               @article={{article}}
               @orientation='h'
               @size='l'
-              @thumbnailSize='300'
+              @thumbnailSize={{array 100 100}}
+              @mediumThumbnailSize={{array 360 240}}
             />
           </NyprMBlockList>
         </section>

--- a/app/utils/dom-fixer.js
+++ b/app/utils/dom-fixer.js
@@ -170,7 +170,7 @@ export default class DomFixer {
     })
   }
 
-  removeHTML(string) {
+  static removeHTML(string) {
     return string.replace(/(<([^>]+)>)/ig,"");
   }
 

--- a/app/utils/dom-fixer.js
+++ b/app/utils/dom-fixer.js
@@ -10,10 +10,10 @@ export default class DomFixer {
     if (typeof rawText === 'undefined') {
       throw new Error("Must provide a string when initializing");
     }
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(rawText, 'text/html');
+    const range = document.createRange();
+    const nodes = range.createContextualFragment(rawText);
 
-    this.nodes = doc.body;
+    this.nodes = nodes;
   }
 
   querySelector(selector) {

--- a/app/utils/dom-fixer.js
+++ b/app/utils/dom-fixer.js
@@ -10,10 +10,10 @@ export default class DomFixer {
     if (typeof rawText === 'undefined') {
       throw new Error("Must provide a string when initializing");
     }
-    const range = document.createRange();
-    const nodes = range.createContextualFragment(rawText);
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(rawText, 'text/html');
 
-    this.nodes = nodes;
+    this.nodes = doc.body;
   }
 
   querySelector(selector) {

--- a/config/environment.js
+++ b/config/environment.js
@@ -60,6 +60,7 @@ module.exports = function(environment) {
     commentsAnchor:     'comments',
     donateCookie:       'goth_donateToutClosed',
     articleViewsCookie: 'goth_articleViews',
+    imgixHost:          'https://gothamist.imgix.net',
 
     // for nypr-auth
     etagAPI: process.env.BROWSER_ID_ENDPOINT,

--- a/config/environment.js
+++ b/config/environment.js
@@ -61,6 +61,7 @@ module.exports = function(environment) {
     donateCookie:       'goth_donateToutClosed',
     articleViewsCookie: 'goth_articleViews',
     imgixHost:          'https://gothamist.imgix.net',
+    imgixPlatypusHost:  'https://gothamist-platypus.imgix.net',
 
     // for nypr-auth
     etagAPI: process.env.BROWSER_ID_ENDPOINT,

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -15,6 +15,11 @@ module.exports = function(defaults) {
     },
     fingerprint: {
       exclude: ['png'], // default images
+    },
+    SRI: {
+      // JS preload fails due to a bug in chromium
+      // patched, should land soon: https://chromium.googlesource.com/chromium/src.git/+/664b6639caeb2e0e7a9755db5a69256050b9d2e2
+      enabled: false,
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "memory-scroll": "^0.9.1",
     "nypr-ads": "^1.1.1",
     "nypr-auth": "^0.2.4",
-    "nypr-design-system": "^1.0.8",
+    "nypr-design-system": "nypublicradio/nypr-design-system#brian/imgix",
     "nypr-metrics": "^0.6.0",
     "qunit-dom": "^0.8.0",
     "sass": "^1.17.0",

--- a/tests/integration/components/article-block/component-test.js
+++ b/tests/integration/components/article-block/component-test.js
@@ -19,22 +19,27 @@ module('Integration | Component | article-block', function(hooks) {
 
     this.set('item', GOTHAMIST_ITEM);
     await render(hbs`
-      <ArticleBlock @article={{item}}/>
+      <ArticleBlock
+        @article={{item}}
+        @thumbnailSize={{array 640 300}}
+      />
     `);
 
-    assert.dom('.c-block__media img').hasAttribute('src');
+    assert.dom('.c-block__media img').hasAttribute('src', imgixUri('/big.jpeg', {w: 640, h: 300}), 'generates thumbnail using `imgix-uri` function');
+    assert.dom('.c-block__media img').doesNotHaveAttribute('srcset', 'no srcset unless third index is passed to thumbnailSize');
+
     assert.dom('.c-block__title').hasText(GOTHAMIST_ITEM.title);
     assert.dom('.c-block__dek').hasText(GOTHAMIST_ITEM.excerptPretty);
 
     await render(hbs`
       <ArticleBlock
         @article={{item}}
-        @thumbnailSize={{array 640 300}}
+        @thumbnailSize={{array 640 300 true}}
         @mediumThumbnailSize={{array 1000 200}}
         @hideExcerpt={{true}}
       />
     `);
-    assert.dom('.c-block__media img').hasAttribute('src', imgixUri('/big.jpeg', {w: 640, h: 300, dpr: 1}), 'generates thumbnail using `imgix-uri` function');
+    assert.dom('.c-block__media img').hasAttribute('srcset', /.*/, 'using a boolean in the third index renders high-dpi srcset');
     assert.dom('.c-block__media source').exists('creates a source element when medium thumbnail sizes are provided')
     assert.dom('.c-block__dek').doesNotExist('respects the @hideExcerpt argument');
   });

--- a/tests/integration/components/article-block/component-test.js
+++ b/tests/integration/components/article-block/component-test.js
@@ -3,7 +3,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-import { FALLBACK_THUMBNAIL } from 'gothamist-web-client/components/article-block/component';
+import { FALLBACK_THUMBNAIL, imgixURI } from 'gothamist-web-client/components/article-block/component';
 
 module('Integration | Component | article-block', function(hooks) {
   setupRenderingTest(hooks);
@@ -13,23 +13,28 @@ module('Integration | Component | article-block', function(hooks) {
       title: 'Article Title',
       excerptPretty: 'Summary of the article',
       section: {label: 'News', basename: 'news'},
-      thumbnail105: 'https://example.com/small.jpeg',
-      thumbnail640: 'https://example.com/big.jpeg',
+      thumbnailPath: '/big.jpeg',
     };
 
     this.set('item', GOTHAMIST_ITEM);
     await render(hbs`
-      <ArticleBlock @article={{item}} @thumbnailSize='105'/>
+      <ArticleBlock @article={{item}}/>
     `);
 
-    assert.dom('.c-block__media img').hasAttribute('src', GOTHAMIST_ITEM.thumbnail105);
+    assert.dom('.c-block__media img').hasAttribute('src');
     assert.dom('.c-block__title').hasText(GOTHAMIST_ITEM.title);
     assert.dom('.c-block__dek').hasText(GOTHAMIST_ITEM.excerptPretty);
 
     await render(hbs`
-      <ArticleBlock @article={{item}} @thumbnailSize='640' @hideExcerpt={{true}}/>
+      <ArticleBlock
+        @article={{item}}
+        @thumbnailSize={{array 640 300}}
+        @mediumThumbnailSize={{array 1000 200}}
+        @hideExcerpt={{true}}
+      />
     `);
-    assert.dom('.c-block__media img').hasAttribute('src', GOTHAMIST_ITEM.thumbnail640, 'respects @thumbnailSize argument');
+    assert.dom('.c-block__media img').hasAttribute('src', imgixURI('/big.jpeg', 640, 300), 'generates thumbnail using `imgixURI` function');
+    assert.dom('.c-block__media source').exists('creates a source element when medium thumbnail sizes are provided')
     assert.dom('.c-block__dek').doesNotExist('respects the @hideExcerpt argument');
   });
 

--- a/tests/integration/components/article-block/component-test.js
+++ b/tests/integration/components/article-block/component-test.js
@@ -34,7 +34,7 @@ module('Integration | Component | article-block', function(hooks) {
         @hideExcerpt={{true}}
       />
     `);
-    assert.dom('.c-block__media img').hasAttribute('src', imgixUri('/big.jpeg', {w: 640, h: 300}), 'generates thumbnail using `imgix-uri` function');
+    assert.dom('.c-block__media img').hasAttribute('src', imgixUri('/big.jpeg', {w: 640, h: 300, dpr: 1}), 'generates thumbnail using `imgix-uri` function');
     assert.dom('.c-block__media source').exists('creates a source element when medium thumbnail sizes are provided')
     assert.dom('.c-block__dek').doesNotExist('respects the @hideExcerpt argument');
   });

--- a/tests/integration/components/article-block/component-test.js
+++ b/tests/integration/components/article-block/component-test.js
@@ -3,7 +3,8 @@ import { setupRenderingTest } from 'ember-qunit';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
 
-import { FALLBACK_THUMBNAIL, imgixURI } from 'gothamist-web-client/components/article-block/component';
+import { FALLBACK_THUMBNAIL } from 'gothamist-web-client/components/article-block/component';
+import { imgixUri } from 'gothamist-web-client/helpers/imgix-uri';
 
 module('Integration | Component | article-block', function(hooks) {
   setupRenderingTest(hooks);
@@ -33,7 +34,7 @@ module('Integration | Component | article-block', function(hooks) {
         @hideExcerpt={{true}}
       />
     `);
-    assert.dom('.c-block__media img').hasAttribute('src', imgixURI('/big.jpeg', 640, 300), 'generates thumbnail using `imgixURI` function');
+    assert.dom('.c-block__media img').hasAttribute('src', imgixUri('/big.jpeg', {w: 640, h: 300}), 'generates thumbnail using `imgix-uri` function');
     assert.dom('.c-block__media source').exists('creates a source element when medium thumbnail sizes are provided')
     assert.dom('.c-block__dek').doesNotExist('respects the @hideExcerpt argument');
   });

--- a/tests/unit/helpers/imgix-uri-test.js
+++ b/tests/unit/helpers/imgix-uri-test.js
@@ -9,12 +9,12 @@ module('Unit | Helper | imgix-uri', function(hooks) {
 
   test('creates an imgix uri for the provided path and params', function(assert) {
     let uri = imgixUri('/foo.jpg', {h: 100, w: 100});
-    assert.equal(uri, `${config.imgixHost}/foo.jpg?fit=crop&q=75&fm=webp&h=100&w=100`, 'uses default params');
+    assert.equal(uri, `${config.imgixHost}/foo.jpg?fit=crop&q=75&h=100&w=100`, 'uses default params');
 
     uri = imgixUri('/foo.jpg', {domain: 'platypus', h: 100, w: 100});
-    assert.equal(uri, `${config.imgixPlatypusHost}/foo.jpg?fit=crop&q=75&fm=webp&h=100&w=100`, 'can switch to platypus host');
+    assert.equal(uri, `${config.imgixPlatypusHost}/foo.jpg?fit=crop&q=75&h=100&w=100`, 'can switch to platypus host');
 
     uri = imgixUri('/foo.jpg', {fit: 'scale'});
-    assert.equal(uri, `${config.imgixHost}/foo.jpg?fit=scale&q=75&fm=webp`, 'can override defaults and leave off width and height');
+    assert.equal(uri, `${config.imgixHost}/foo.jpg?fit=scale&q=75`, 'can override defaults and leave off width and height');
   });
 });

--- a/tests/unit/helpers/imgix-uri-test.js
+++ b/tests/unit/helpers/imgix-uri-test.js
@@ -1,0 +1,20 @@
+import { imgixUri } from 'gothamist-web-client/helpers/imgix-uri';
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+import config from 'gothamist-web-client/config/environment';
+
+module('Unit | Helper | imgix-uri', function(hooks) {
+  setupTest(hooks);
+
+  test('creates an imgix uri for the provided path and params', function(assert) {
+    let uri = imgixUri('/foo.jpg', {h: 100, w: 100});
+    assert.equal(uri, `${config.imgixHost}/foo.jpg?fit=crop&q=75&fm=webp&h=100&w=100`, 'uses default params');
+
+    uri = imgixUri('/foo.jpg', {domain: 'platypus', h: 100, w: 100});
+    assert.equal(uri, `${config.imgixPlatypusHost}/foo.jpg?fit=crop&q=75&fm=webp&h=100&w=100`, 'can switch to platypus host');
+
+    uri = imgixUri('/foo.jpg', {fit: 'scale'});
+    assert.equal(uri, `${config.imgixHost}/foo.jpg?fit=scale&q=75&fm=webp`, 'can override defaults and leave off width and height');
+  });
+});

--- a/tests/unit/helpers/imgix-uri-test.js
+++ b/tests/unit/helpers/imgix-uri-test.js
@@ -9,12 +9,12 @@ module('Unit | Helper | imgix-uri', function(hooks) {
 
   test('creates an imgix uri for the provided path and params', function(assert) {
     let uri = imgixUri('/foo.jpg', {h: 100, w: 100});
-    assert.equal(uri, `${config.imgixHost}/foo.jpg?fit=crop&q=75&h=100&w=100`, 'uses default params');
+    assert.equal(uri, `${config.imgixHost}/foo.jpg?crop=faces&fit=crop&auto=compress,format&fm=jpg&h=100&w=100`, 'uses default params');
 
     uri = imgixUri('/foo.jpg', {domain: 'platypus', h: 100, w: 100});
-    assert.equal(uri, `${config.imgixPlatypusHost}/foo.jpg?fit=crop&q=75&h=100&w=100`, 'can switch to platypus host');
+    assert.equal(uri, `${config.imgixPlatypusHost}/foo.jpg?crop=faces&fit=crop&auto=compress,format&fm=jpg&h=100&w=100`, 'can switch to platypus host');
 
     uri = imgixUri('/foo.jpg', {fit: 'scale'});
-    assert.equal(uri, `${config.imgixHost}/foo.jpg?fit=scale&q=75`, 'can override defaults and leave off width and height');
+    assert.equal(uri, `${config.imgixHost}/foo.jpg?crop=faces&fit=scale&auto=compress,format&fm=jpg`, 'can override defaults and leave off width and height');
   });
 });

--- a/tests/unit/utils/dom-fixer-test.js
+++ b/tests/unit/utils/dom-fixer-test.js
@@ -14,7 +14,7 @@ module('Unit | Utility | dom-fixer', function() {
     const HTML = '<p>hello <strong>world</strong></p>';
     let domFixer = new DomFixer(HTML);
 
-    assert.ok(domFixer.nodes instanceof HTMLBodyElement, 'makes a document body out of some text');
+    assert.ok(domFixer.nodes instanceof DocumentFragment, 'makes a document fragment out of some text');
     assert.equal(domFixer.nodes.firstElementChild.outerHTML, HTML);
 
     assert.deepEqual(domFixer.querySelector('p'), domFixer.nodes.querySelector('p'), 'calling querySelector on the instance is the same as calling it on the nodes');

--- a/tests/unit/utils/dom-fixer-test.js
+++ b/tests/unit/utils/dom-fixer-test.js
@@ -27,9 +27,9 @@ module('Unit | Utility | dom-fixer', function() {
     `;
     let domFixer = new DomFixer(HTML);
 
-    assert.equal(4, domFixer.nodes.childNodes.length, 'should be 4 nodes in the parsed output');
-    assert.deepEqual(['P', '#text', 'P', '#text'], [...domFixer.nodes.childNodes].map(n => n.nodeName));
-    assert.deepEqual(['hello', '', 'world', ''], [...domFixer.nodes.childNodes].map(n => n.textContent.trim()));
+    assert.equal(5, domFixer.nodes.childNodes.length, 'should be 5 nodes in the parsed output');
+    assert.deepEqual(['#text', 'P', '#text', 'P', '#text'], [...domFixer.nodes.childNodes].map(n => n.nodeName));
+    assert.deepEqual(['', 'hello', '', 'world', ''], [...domFixer.nodes.childNodes].map(n => n.textContent.trim()));
 
     domFixer.removeEmptyNodes();
 

--- a/tests/unit/utils/dom-fixer-test.js
+++ b/tests/unit/utils/dom-fixer-test.js
@@ -14,7 +14,7 @@ module('Unit | Utility | dom-fixer', function() {
     const HTML = '<p>hello <strong>world</strong></p>';
     let domFixer = new DomFixer(HTML);
 
-    assert.ok(domFixer.nodes instanceof DocumentFragment, 'makes a document fragment out of some text');
+    assert.ok(domFixer.nodes instanceof HTMLBodyElement, 'makes a document body out of some text');
     assert.equal(domFixer.nodes.firstElementChild.outerHTML, HTML);
 
     assert.deepEqual(domFixer.querySelector('p'), domFixer.nodes.querySelector('p'), 'calling querySelector on the instance is the same as calling it on the nodes');
@@ -27,9 +27,9 @@ module('Unit | Utility | dom-fixer', function() {
     `;
     let domFixer = new DomFixer(HTML);
 
-    assert.equal(5, domFixer.nodes.childNodes.length, 'should be 5 nodes in the parsed output');
-    assert.deepEqual(['#text', 'P', '#text', 'P', '#text'], [...domFixer.nodes.childNodes].map(n => n.nodeName));
-    assert.deepEqual(['', 'hello', '', 'world', ''], [...domFixer.nodes.childNodes].map(n => n.textContent.trim()));
+    assert.equal(4, domFixer.nodes.childNodes.length, 'should be 4 nodes in the parsed output');
+    assert.deepEqual(['P', '#text', 'P', '#text'], [...domFixer.nodes.childNodes].map(n => n.nodeName));
+    assert.deepEqual(['hello', '', 'world', ''], [...domFixer.nodes.childNodes].map(n => n.textContent.trim()));
 
     domFixer.removeEmptyNodes();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8920,10 +8920,9 @@ nypr-auth@^0.2.4:
     ember-get-config "^0.2.2"
     ember-simple-auth "^1.7.0"
 
-nypr-design-system@^1.0.8:
+nypr-design-system@nypublicradio/nypr-design-system#brian/imgix:
   version "1.0.8"
-  resolved "https://registry.yarnpkg.com/nypr-design-system/-/nypr-design-system-1.0.8.tgz#074fa5c988426da6cfd0a66766c4e136d5caa267"
-  integrity sha512-/3AuuL1BXEjRVlaM1/Ib/icT5vjP1GLe9YSNf1teqpNfj8N/uqYX9R8A8BhKIhzqlfrSg45tO5LaCeYkQ6wnzg==
+  resolved "https://codeload.github.com/nypublicradio/nypr-design-system/tar.gz/01994f7aadca48b379752601a790d94f4f44807d"
   dependencies:
     "@babel/core" "^7.0.0"
     broccoli-merge-files "^0.8.0"


### PR DESCRIPTION
This PR collects a few optimizations on the way to improve load time.

Imgix is a CDN we can use for specifying image crops. Imgix is configured to pull in images from topics (i.e. gothamist.com) and platypus (i.e. cmsplatypus.gothamist.com); all we need to do is swap out the domain for the correct imigix domain, and add our preferred parameters.

In the interest of "biggest win", this PR only implements imgix for article thumbnails and gallery images (since I was on a roll). Embedded images and image leads can be address in another PR.

You may also notice that the alt tag and aria label attrs have been changed. Pulling in the values off of the parsed body kicked off an image request for any `<img/>` tags encountered, which defeats the purpose of pulling our images through the CDN (the pre-parsed images all point to the full-size domains). I attempted to work around this by using `DOMParser`, which does not exhibit the same behavior, but the resulting `Document` (vs. a `DocumentFragment`) ends up being incompatible for moving nodes around (unless things like `window.importNode` are used, which also triggers image requests).

Another approach that just occurred to me would be to produce a document using `DOMParser`, then with that realized DOM, replace all the embedded images in place to point to imgix. I suppose because that will result in double requests (once when imported, once when actually added to the DOM), that would be sub optimal.

Some other optimizations:
- removes an unused font (Lato)
- preload and preconnect tags

One last thing: this turns off SRI for `preload` compat. There's a bug in chromium that prevents this from working as intended if an SRI hash is on the preloaded resource. The bug was patched [yesterday](https://bugs.chromium.org/p/chromium/issues/detail?id=677022#c49) (!!), so hopefully it should land in Chrome soon enough.

depends on nypr-design-system#20