### PR TITLE
only hide gothamist logo letters on galleries on narrow screens

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -92,7 +92,9 @@ $ember-basic-dropdown-content-z-index: 10000;
 }
 
 .is-hiding-letters .gothamist-logo-icon .letters {
-  display: none;
+  @media only screen and (max-width: 768px) {
+    display: none;
+  }
 }
 
 // improve side menu scrolling


### PR DESCRIPTION
[DS-384](https://jira.wnyc.org/browse/DS-384)