### PR TITLE
derive `section` using new `ancestry` key

### DIFF
--- a/app/components/article-block/component.js
+++ b/app/components/article-block/component.js
@@ -75,7 +75,7 @@ export default Component.extend({
       path String
       publishedMoment Moment
       relatedAuthors Array[Object<first_name String, last_name String, slug String>]
-      section Object<label String, basename String>
+      section Object<title String, slug String>
       thumbnail Object<id String>
       title String
     ```
@@ -199,7 +199,7 @@ export default Component.extend({
     if (!thumbnail) {
       // fallback image
       let section = this.article.section || {};
-      return FALLBACK_THUMBNAIL[section.basename];
+      return FALLBACK_THUMBNAIL[section.slug];
     }
 
     if (thumbnail) {

--- a/app/components/article-block/template.hbs
+++ b/app/components/article-block/template.hbs
@@ -10,13 +10,15 @@
   />
 
   <block.object as |o|>
-    {{#if (and @article.section.label (not @hideEyebrow))}}
+    {{#if (and @article.section.title (not @hideEyebrow))}}
       {{#if @article.isSponsored}}
         <o.eyebrow @kickerClass="o-kicker--sponsored" @text="Sponsored"/>
       {{else}}
         <o.eyebrow
-          @route={{array 'sections' @article.section.basename}}
-          @text={{@article.section.label}}/>
+          @route={{array 'sections' @article.section.slug}}
+          @text={{@article.section.title}}
+          data-test-section-label
+        />
       {{/if}}
     {{/if}}
 

--- a/app/components/article-recirc/template.hbs
+++ b/app/components/article-recirc/template.hbs
@@ -3,7 +3,7 @@
     {{#if this.popular}}
       <NyprMBlockList
         class="u-spacing--and-half"
-        @heading={{concat 'Popular in ' @article.section.label}}
+        @heading={{concat 'Popular in ' @article.section.title}}
         @items={{slice 0 3 this.popular}}
         as |article|>
         <ArticleBlock
@@ -21,7 +21,7 @@
 
   <blg.col2 class="c-recirc-tout__col2" data-test-recirc-featured>
     <h2 class="o-section__heading o-bg-text-accent">
-      Featured in {{@article.section.label}}
+      Featured in {{@article.section.title}}
     </h2>
     {{#if this.featured}}
       <ArticleBlock

--- a/app/models/article.js
+++ b/app/models/article.js
@@ -80,12 +80,12 @@ export default Page.extend({
 
   breadcrumb: computed('section', function() {
     return;
-    // if (!this.section.basename) {
+    // if (!this.section.slug) {
     //   return;
     // }
     // let breadcrumb = [{
-    //   route: ['sections', this.section.basename],
-    //   label: this.section.label
+    //   route: ['sections', this.section.slug],
+    //   label: this.section.title
     // }];
     // if (this.isSponsored) {
     //   breadcrumb.push({label: 'Sponsored'});
@@ -152,6 +152,6 @@ export default Page.extend({
       .map(tag => tag.replace(/^@/,''));
   }),
   adBindings: computed(function() {
-    return ['internalTags:tags','section.basename:Category'];
+    return ['internalTags:tags','section.slug:Category'];
   }),
 });

--- a/app/models/article.js
+++ b/app/models/article.js
@@ -6,12 +6,15 @@ import { computed } from '@ember/object';
 import { reads, bool } from '@ember/object/computed';
 
 
+export const SECTION_PAGE_TYPE = 'standardpages.IndexPage';
+
 export const LEAD_GALLERY = 'lead_gallery';
 export const LEAD_VIDEO   = 'lead_video';
 export const LEAD_AUDIO   = 'lead_audio';
 export const LEAD_IMAGE   = 'lead_image';
 
 export default Page.extend({
+  ancestry:    DS.attr(),
   body:        DS.attr(),
   description: DS.attr('string'),
 
@@ -46,9 +49,20 @@ export default Page.extend({
   }),
   modifiedMoment: reads('updatedDate'),
 
-  section: computed('categories', function() {
-    // TBD implemented
-    return '';
+  section: computed('ancestry', function() {
+    if (!this.ancestry || !this.ancestry.length) {
+      return {};
+    }
+    const NEAREST_SECTION = this.ancestry.findBy('meta.type', SECTION_PAGE_TYPE);
+
+    if (NEAREST_SECTION) {
+      return {
+        title: NEAREST_SECTION.title,
+        slug: NEAREST_SECTION.slug,
+      };
+    } else {
+      return {};
+    }
   }),
 
   hasMain: reads('showAsFeature'),

--- a/app/routes/article.js
+++ b/app/routes/article.js
@@ -40,7 +40,7 @@ export default Route.extend({
       ogTitle: model.title, // don't include " - Gothamist" like in <title> tag
       publishedTime: model.publishedMoment.format(),
       modifiedTime: model.modifiedMoment.format(),
-      section: model.section.label,
+      section: model.section.title,
       tags: model.displayTags,
       authors: model.authors,
       image: {
@@ -54,7 +54,7 @@ export default Route.extend({
       this.set('metrics.context.pageData', {
         // merge with existing value, which is the previous URL set in the application route
         ...this.metrics.context.pageData,
-        sections: model.section.label || model.section.basename,
+        sections: model.section.title || model.section.slug,
         authors: model.authors,
         path: `/${model.path}`,
       });

--- a/mirage/factories/article.js
+++ b/mirage/factories/article.js
@@ -4,9 +4,50 @@ import { Factory, faker, trait } from 'ember-cli-mirage';
 import {
   CMS_TIMESTAMP_FORMAT,
   slug,
+  section,
 } from './consts';
 
+
 export default Factory.extend({
+  ancestry() {
+    return [{
+      id: faker.random.number(100, 300),
+      meta: {
+        type: 'news.ArticleIndex',
+        detail_url: 'http://localhost/api/v2/pages/12/',
+        html_url: 'http://localhost/news/articles/',
+      },
+      title: 'Articles',
+      slug: 'articles',
+    }, {
+      id: faker.random.number(300, 500),
+      meta: {
+        type: 'standardpages.IndexPage',
+        detail_url: 'http://localhost/api/v2/pages/8/',
+        html_url: 'http://localhost/news/',
+      },
+      title: this._section[0].toUpperCase() + this._section.slice(1),
+      slug: this._section,
+    }, {
+      id: faker.random.number(500, 700),
+      meta: {
+        type: 'home.HomePage',
+        detail_url: 'http://localhost/api/v2/pages/3/',
+        html_url: 'http://localhost/',
+      },
+      title: 'Home',
+      slug: 'home',
+    }, {
+      id: 1,
+      meta: {
+        type: 'wagtailcore.Page',
+        detail_url: 'http://localhost/api/v2/pages/1/',
+        html_url: null,
+      },
+      title: 'Root',
+      slug: 'root',
+    }];
+  },
   body: () => ([
     {
       type: 'paragraph',
@@ -30,7 +71,7 @@ export default Factory.extend({
     }
   ]),
 
-  legacy_id: () => faker.random.number(80000),
+  legacy_id: () => faker.random.number(50000, 80000),
 
   listing_title: '',
   listing_summary: '',
@@ -85,4 +126,7 @@ export default Factory.extend({
   now: trait({
     publication_date: moment.utc().format(CMS_TIMESTAMP_FORMAT),
   }),
+
+  // mirage-only attrs
+  _section: section(),
 });

--- a/mirage/factories/consts.js
+++ b/mirage/factories/consts.js
@@ -1,6 +1,7 @@
 import { faker } from 'ember-cli-mirage';
 
 export const slug = () => faker.lorem.words(3).split(' ').join('-');
+export const section = () => faker.random.arrayElement(['news', 'food', 'arts']);
 
 export const CMS_TIMESTAMP_FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSSSSS[Z]';
 export const DATE_FORMAT = 'YYYYMMDDhhmmss';

--- a/mirage/factories/index-page.js
+++ b/mirage/factories/index-page.js
@@ -42,7 +42,10 @@ export default Factory.extend({
   afterCreate(page, server) {
     if (!page.descendants.length) {
       page.update({
-        descendants: server.createList('article', COUNT * 2, {indexPage: page}),
+        descendants: server.createList('article', COUNT * 2, {
+          indexPage: page,
+          _section: page.meta.slug
+        }),
       });
     }
   }

--- a/mirage/serializers/article.js
+++ b/mirage/serializers/article.js
@@ -8,6 +8,8 @@ export default ApplicationSerializer.extend({
 
     delete json.indexPage; // mirage only
 
+    delete json._section;
+
     return {
       ...json,
       meta: {

--- a/tests/acceptance/analytics-test.js
+++ b/tests/acceptance/analytics-test.js
@@ -7,6 +7,7 @@ import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
 import * as uuid from 'uuid/v1';
 
 import config from 'gothamist-web-client/config/environment';
+import { ANCESTRY } from '../unit/fixtures/article-fixtures';
 
 
 module('Acceptance | analytics', function(hooks) {
@@ -39,10 +40,7 @@ module('Acceptance | analytics', function(hooks) {
       id: 'gallery',
       author_nickname: AUTHOR,
       authored_on_utc: '20190101120000',
-      categories: [{
-        basename: 'news',
-        label: SECTION
-      }],
+      ancestry: ANCESTRY,
       tags: TAGS,
       title: TITLE,
     });

--- a/tests/acceptance/article-test.js
+++ b/tests/acceptance/article-test.js
@@ -11,6 +11,7 @@ import { SERVICE_MAP } from 'nypr-design-system/components/nypr-m-share-tools';
 import { inViewport } from 'nypr-design-system/helpers/in-viewport';
 
 import config from 'gothamist-web-client/config/environment';
+import { ANCESTRY } from '../unit/fixtures/article-fixtures';
 
 
 const URL = UTM => {
@@ -42,8 +43,8 @@ module('Acceptance | article', function(hooks) {
   });
 
   skip('visiting article route', async function(assert) {
-    const article = server.create('article', {categories: [{basename: 'food'}]});
-    server.createList('article', 5, {terms: ['@main'], categories: [{basename: 'food'}]});
+    const article = server.create('article', {_section: 'food'});
+    server.createList('article', 5, {terms: ['@main'], _section: 'food'});
 
     await visit(`/${article.path}`);
 
@@ -239,7 +240,7 @@ module('Acceptance | article', function(hooks) {
 
   skip('chartbeat virtualPage is called with correct args correct number of times', async function(assert) {
     const article = server.create('article', {
-      categories: [{basename: 'food'}],
+      ancestry: ANCESTRY,
     });
 
     const spy = this.spy(window.pSUPERFLY, 'virtualPage');
@@ -262,7 +263,7 @@ module('Acceptance | article', function(hooks) {
       "virtualReferrer",
     ]);
     assert.deepEqual(firstCall, {
-      sections: `Gothamist,${article.categories[0].basename},Gothamist ${article.categories[0].basename}`,
+      sections: `Gothamist,News,Gothamist News`,
       authors: article.author_nickname,
       path: `/${article.path}`,
       virtualReferrer: '/',
@@ -295,7 +296,7 @@ module('Acceptance | article', function(hooks) {
     const SECTION = 'news';
     const AUTHOR = 'Foo Bar';
     server.create('article', {
-      categories: [{basename: SECTION}],
+      _section: SECTION,
       author_nickname: AUTHOR,
       path: 'foo',
     });
@@ -312,13 +313,13 @@ module('Acceptance | article', function(hooks) {
     // first article
     server.create('article', {
       path: 'foo',
-      categories: [{basename: 'food'}]
+      _section: 'food',
     });
     // final article
     server.create('article', {
       path: 'bar',
       terms: ['@main'],
-      categories: [{basename: 'food'}]
+      _section: 'food',
     });
 
     await visit('/');

--- a/tests/acceptance/gallery-test.js
+++ b/tests/acceptance/gallery-test.js
@@ -19,7 +19,7 @@ module('Acceptance | gallery', function(hooks) {
   })
 
   skip('gallery should contain 2 slides and 0 ads', async function(assert) {
-    const article = server.create('article', 'mtGallery', {categories: [{basename: 'food'}]});
+    const article = server.create('article', 'mtGallery', {_section: 'food'});
     // 7 articles - 5 = 2
     article.gallery_array.splice(0, 5)
     article.gallery_captions.splice(0, 5)
@@ -34,7 +34,7 @@ module('Acceptance | gallery', function(hooks) {
   });
 
   skip('gallery should contain 3 slides and 1 ad', async function(assert) {
-    const article = server.create('article', 'mtGallery', {categories: [{basename: 'food'}]});
+    const article = server.create('article', 'mtGallery', {_section: 'food'});
     // 7 articles - 4 = 3
     article.gallery_array.splice(0, 4);
     article.gallery_captions.splice(0, 4);
@@ -48,7 +48,7 @@ module('Acceptance | gallery', function(hooks) {
   });
 
   skip('gallery should contain 5 slides and 1 ads', async function(assert) {
-    const article = server.create('article', 'mtGallery', {categories: [{basename: 'food'}]});
+    const article = server.create('article', 'mtGallery', {_section: 'food'});
     // 7 articles - 2 = 6
     article.gallery_array.splice(0, 2)
     article.gallery_captions.splice(0, 2)
@@ -63,7 +63,7 @@ module('Acceptance | gallery', function(hooks) {
 
 
   skip('gallery should contain 6 slides and 2 ads', async function(assert) {
-    const article = server.create('article', 'mtGallery', {categories: [{basename: 'food'}]});
+    const article = server.create('article', 'mtGallery', {_section: 'food'});
     // 7 articles - 1 = 6
     article.gallery_array.splice(0, 1)
     article.gallery_captions.splice(0, 1)
@@ -77,7 +77,7 @@ module('Acceptance | gallery', function(hooks) {
   });
 
   skip('gallery should contain 14 slides and still only 2 ads', async function(assert) {
-    const article = server.create('article', 'mtGallery', {categories: [{basename: 'food'}]});
+    const article = server.create('article', 'mtGallery', {_section: 'food'});
     // 7 articles + 7 = 14
     article.gallery_array.push(...article.gallery_array);
     article.gallery_captions.push(...article.gallery_captions);

--- a/tests/acceptance/tags-test.js
+++ b/tests/acceptance/tags-test.js
@@ -11,13 +11,14 @@ module('Acceptance | tags', function(hooks) {
   setupMirage(hooks);
 
   test('visiting /tags', async function(assert) {
-    server.createList('article', COUNT * 5, {tags: ['dogs and cats']});
+    server.createList('article', COUNT * 5, {tags: ['dogs and cats'], _section: 'food'});
     await visit('/tags/dogs%20and%20cats');
 
     assert.equal(currentURL(), '/tags/dogs%20and%20cats');
 
     assert.dom('[data-test-block]').exists({count: COUNT});
     assert.dom('[data-test-tag-heading]').hasText('Dogs And Cats');
+    assert.dom('[data-test-section-label]').hasText('Food', 'section label is populated');
 
     await click('[data-test-more-results]');
 

--- a/tests/integration/components/article-block/component-test.js
+++ b/tests/integration/components/article-block/component-test.js
@@ -15,12 +15,17 @@ module('Integration | Component | article-block', function(hooks) {
   test('it renders', async function(assert) {
     const recent = moment().subtract(1, 'day');
     const IMAGE_ID = 100;
+    const SECTION = 'News';
     const GOTHAMIST_ITEM = {
       title: 'Article Title',
       description: 'Summary of the article',
       publishedMoment: recent,
       thumbnail: {
         id: IMAGE_ID,
+      },
+      section: {
+        slug: 'news',
+        title: SECTION,
       }
     };
 
@@ -41,6 +46,8 @@ module('Integration | Component | article-block', function(hooks) {
 
     assert.dom('[data-test-timestamp]').hasText(recent.format(TIMESTAMP_FORMAT_NO_YEAR));
 
+    assert.dom('[data-test-section-label]').hasText(SECTION);
+
     await render(hbs`
       <ArticleBlock
         @article={{item}}
@@ -58,7 +65,7 @@ module('Integration | Component | article-block', function(hooks) {
     const GOTHAMIST_ITEM = {
       title: 'Article Title',
       description: 'Summary of the article',
-      section: {label: 'News', basename: 'news'},
+      section: {title: 'News', slug: 'news'},
     };
 
     this.set('item', GOTHAMIST_ITEM);
@@ -68,21 +75,21 @@ module('Integration | Component | article-block', function(hooks) {
     assert.dom('.c-block__media img').hasAttribute('srcset', FALLBACK_THUMBNAIL.news.srcSet, 'uses fallback based on section: news');
     assert.dom('.c-block__media source').hasAttribute('srcset', FALLBACK_THUMBNAIL.news.srcM, 'uses fallback based on section: news');
 
-    this.set('item.section.basename', 'food');
+    this.set('item.section.slug', 'food');
     await render(hbs`<ArticleBlock @article={{item}} />`);
 
     assert.dom('.c-block__media img').hasAttribute('src', FALLBACK_THUMBNAIL.food.srcS, 'uses fallback based on section: food');
     assert.dom('.c-block__media img').hasAttribute('srcset', FALLBACK_THUMBNAIL.food.srcSet, 'uses fallback based on section: food');
     assert.dom('.c-block__media source').hasAttribute('srcset', FALLBACK_THUMBNAIL.food.srcM, 'uses fallback based on section: food');
 
-    this.set('item.section.basename', 'arts & entertainment');
+    this.set('item.section.slug', 'arts & entertainment');
     await render(hbs`<ArticleBlock @article={{item}} />`);
 
     assert.dom('.c-block__media img').hasAttribute('src', FALLBACK_THUMBNAIL['arts & entertainment'].srcS, 'uses fallback based on section: arts');
     assert.dom('.c-block__media img').hasAttribute('srcset', FALLBACK_THUMBNAIL['arts & entertainment'].srcSet, 'uses fallback based on section: arts');
     assert.dom('.c-block__media source').hasAttribute('srcset', FALLBACK_THUMBNAIL['arts & entertainment'].srcM, 'uses fallback based on section: arts');
 
-    this.set('item.section.basename', undefined);
+    this.set('item.section.slug', undefined);
     await render(hbs`<ArticleBlock @article={{item}} />`);
 
     assert.dom('.c-block__media img').hasAttribute('src', FALLBACK_THUMBNAIL[undefined].srcS, 'no category src');

--- a/tests/integration/components/article-recirc/component-test.js
+++ b/tests/integration/components/article-recirc/component-test.js
@@ -10,7 +10,7 @@ import hbs from 'htmlbars-inline-precompile';
 const ARTICLE = {
   id: 100,
   section: {
-    basename: 'foo',
+    slug: 'foo',
   }
 };
 

--- a/tests/unit/fixtures/article-fixtures.js
+++ b/tests/unit/fixtures/article-fixtures.js
@@ -1,3 +1,41 @@
+export const ANCESTRY = [{
+  "id": 12,
+  "meta": {
+    "type": "news.ArticleIndex",
+    "detail_url": "http://localhost/api/v2/pages/12/",
+    "html_url": "http://localhost/news/articles/"
+  },
+  "title": "Articles",
+  "slug": "articles"
+}, {
+  "id": 8,
+  "meta": {
+    "type": "standardpages.IndexPage",
+    "detail_url": "http://localhost/api/v2/pages/8/",
+    "html_url": "http://localhost/news/"
+  },
+  "title": "News",
+  "slug": "news"
+}, {
+  "id": 3,
+  "meta": {
+    "type": "home.HomePage",
+    "detail_url": "http://localhost/api/v2/pages/3/",
+    "html_url": "http://localhost/"
+  },
+  "title": "Home",
+  "slug": "home"
+}, {
+  "id": 1,
+  "meta": {
+    "type": "wagtailcore.Page",
+    "detail_url": "http://localhost/api/v2/pages/1/",
+    "html_url": null
+  },
+  "title": "Root",
+  "slug": "root"
+}];
+
 export const DOUBLE_BREAKS = `
   <p>
     Massaria commonly affects London Plane trees. A<a href="http://www.londontreereports-surveys.co.uk/Fungus/Massaria-Disease-of-Plane.html"> tree consultant explains</a>, "The disease always attacks the upper side of the branch and is difficult to spot from the ground for this reason. In the early stages a long pink brown strip can be seen, followed by brown and then a black strip with spores." A major cause of massaria is drought stress.

--- a/tests/unit/models/article-test.js
+++ b/tests/unit/models/article-test.js
@@ -1,6 +1,9 @@
 import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 
+import { ANCESTRY } from '../fixtures/article-fixtures';
+
+
 module('Unit | Model | article', function(hooks) {
   setupTest(hooks);
 
@@ -9,5 +12,15 @@ module('Unit | Model | article', function(hooks) {
     let store = this.owner.lookup('service:store');
     let model = store.createRecord('article', {});
     assert.ok(model);
+  });
+
+  // test computeds
+  test('section is computed from ancestry', function(assert) {
+    let store = this.owner.lookup('service:store');
+    let model = store.createRecord('article', {
+      ancestry: ANCESTRY,
+    });
+
+    assert.deepEqual(model.section, {slug: 'news', title: 'News'});
   });
 });


### PR DESCRIPTION
[ticket](https://jira.wnyc.org/browse/CMS-581)

adds a new computed property to the article model. Looks at the new `ancestry` field and grabs the first item in the array that has a `type` value of `standardpages.IndexPage`, which I've set as the const `SECTION_PAGE_TYPE` for reference.

The final commit in this diff is a pretty dumb find/replace for all the places where the old `basename` and `label` keys were used to get at the different category values (category is what we used to call section).

For review, I'd suggest looking at the first four commits only, to reduce the noise: e6ee1a2b0a80bfe18b78519aca0e68a714b844f1...4027b6d423adbadcba4bcebf164f0a76b85e70f6