### PR TITLE
Update homepage for wagtail

### DIFF
--- a/app/controllers/index.js
+++ b/app/controllers/index.js
@@ -35,9 +35,8 @@ export default Controller.extend({
     const { TOTAL_COUNT } = this;
 
     this.set('riverQuery', {
-      index: 'gothamist',
-      count: TOTAL_COUNT,
-      page: 2,
+      limit: TOTAL_COUNT,
+      show_on_index_listing: true,
     });
 
     let hideAsk = this.cookies.exists(HIDE_PLEDGE_COOKIE);

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -9,7 +9,7 @@ import config from '../config/environment';
 import addCommentCount from '../utils/add-comment-count';
 
 
-const BASE_COUNT = 28;
+const BASE_COUNT = 16;
 export const MAIN_COUNT = 4;
 export const TOTAL_COUNT = BASE_COUNT + MAIN_COUNT;
 export const GROUP_SIZE = 7;
@@ -49,13 +49,12 @@ export default Route.extend({
       sponsored: this.getSponsoredPost(),
       sponsoredMain: this.getSponsoredMain(),
       main: this.store.query('article', {
-        index: 'gothamist',
-        term: '@main',
-        count: MAIN_COUNT,
+        show_as_feature: true,
+        limit: MAIN_COUNT,
       }),
       river: this.store.query('article', {
-        index: 'gothamist',
-        count: TOTAL_COUNT,
+        show_on_index_listing: true,
+        limit: TOTAL_COUNT,
       }),
       wnyc: getWnycStories(),
     }).then(results => {
@@ -83,9 +82,8 @@ export default Route.extend({
   // filter it out if it's older than 24 hours
   async getSponsoredPost() {
     let { firstObject:post } = await this.store.query('article', {
-      index: 'gothamist',
-      term: '@sponsor',
-      count: 1,
+      sponsored_content: true,
+      limit: 1,
     });
 
     if (!post) {
@@ -100,9 +98,9 @@ export default Route.extend({
   // filter if it's not between 24 and 48 hours old
   async getSponsoredMain() {
     let { firstObject:post } = await this.store.query('article', {
-      index: 'gothamist',
-      term: ['@sponsor', '@main'],
-      count: 1,
+      sponsored_content: true,
+      show_as_feature: true,
+      limit: 1,
     });
 
     if (!post) {

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -9,7 +9,7 @@ import config from '../config/environment';
 import addCommentCount from '../utils/add-comment-count';
 
 
-const BASE_COUNT = 16;
+const BASE_COUNT = 28;
 export const MAIN_COUNT = 4;
 export const TOTAL_COUNT = BASE_COUNT + MAIN_COUNT;
 export const GROUP_SIZE = 7;

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -177,7 +177,6 @@
         <AriaLoadMessage @message="More Results Loaded" />
         {{#animated-each page use=transition initialInsertion=true as |set|}}
           <div class="l-container l-container--14col">
-
             <ArticleList @articles={{set}} @ad='gothamist/index/midpage/repeating' />
           </div>
         {{/animated-each}}

--- a/mirage/factories/homepage.js
+++ b/mirage/factories/homepage.js
@@ -1,0 +1,16 @@
+import { Factory } from 'ember-cli-mirage';
+
+export default Factory.extend({
+  meta: () => ({
+    first_published_at: "2019-06-25T15:37:41.806033-04:00",
+    type: "home.HomePage",
+    detail_url: "https://cms.demo.nypr.digital/api/v2/pages/3/",
+    html_url: "https://cms.demo.nypr.digital/",
+    slug: "home"
+  }),
+  title: "Home",
+  page_collection_relationship: () => ([{
+    title: "WNYC Cross-Posting",
+    pages: []
+  }])
+});

--- a/mirage/models/homepage.js
+++ b/mirage/models/homepage.js
@@ -1,0 +1,4 @@
+import { Model } from 'ember-cli-mirage';
+
+export default Model.extend({
+});

--- a/tests/acceptance/homepage-test.js
+++ b/tests/acceptance/homepage-test.js
@@ -1,6 +1,6 @@
 import moment from 'moment';
 
-import { module, skip /* test */ } from 'qunit';
+import { module, test } from 'qunit';
 import { visit, currentURL, click, findAll } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import setupMirage from 'ember-cli-mirage/test-support/setup-mirage';
@@ -13,9 +13,9 @@ module('Acceptance | homepage', function(hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
 
-  skip('visiting homepage', async function(assert) {
+  test('visiting homepage', async function(assert) {
     server.createList('article', 10, {
-      tags: ['@main']
+      show_as_feature: true,
     });
     server.createList('article', TOTAL_COUNT * 2);
 
@@ -28,7 +28,7 @@ module('Acceptance | homepage', function(hooks) {
     assert.dom('[data-test-featured-block-list] [data-test-block]').exists();
     assert.dom('[data-test-block]').exists({count: TOTAL_COUNT});
 
-    const mainArticleInRiver = server.schema.articles.where({tags:['@main']}).slice(-1).models[0];
+    const mainArticleInRiver = server.schema.articles.where({show_as_feature: true}).slice(-1).models[0];
     assert.dom(`[data-test-block="${mainArticleInRiver.id}"]`).doesNotHaveClass('c-block--horizontal', 'articles in the "river" tagged main should not have a "--horizontal" modifier class');
 
     await click('[data-test-more-results]');
@@ -36,7 +36,7 @@ module('Acceptance | homepage', function(hooks) {
     assert.dom('[data-test-block]').exists({count: TOTAL_COUNT * 2}, 'Clicking "read more" brings in another set of results equal to the amount of TOTAL_COUNT');
   });
 
-  skip('sponsored posts younger than 24 hours appear in sponsored tout', async function(assert) {
+  test('sponsored posts younger than 24 hours appear in sponsored tout', async function(assert) {
     const TITLE = 'foo';
 
     server.create('article', {
@@ -51,7 +51,7 @@ module('Acceptance | homepage', function(hooks) {
     assert.dom('[data-test-block="sponsored"]').exists({count: 1}, 'should only appear once')
   });
 
-  skip('sponsored posts older than 24 hours do not appear in sponsored tout', async function(assert) {
+  test('sponsored posts older than 24 hours do not appear in sponsored tout', async function(assert) {
 
     server.create('article', {
       tags: ['@sponsor'],
@@ -62,7 +62,7 @@ module('Acceptance | homepage', function(hooks) {
     assert.dom('[data-test-sponsored-tout]').doesNotExist();
   });
 
-  skip('sponsored posts tagged @main and between 24 and 48 hours old appear in featured area', async function(assert) {
+  test('sponsored posts tagged @main and between 24 and 48 hours old appear in featured area', async function(assert) {
     server.create('article', {
       id: 'sponsored-main',
       tags: ['@sponsor', '@main'],
@@ -83,7 +83,7 @@ module('Acceptance | homepage', function(hooks) {
     assert.dom('[data-test-sponsored-tout] .c-block__title').exists('regular sponsored post should also appear too');
   });
 
-  skip('articles get updated with commentCount', async function(assert) {
+  test('articles get updated with commentCount', async function(assert) {
     server.createList('article', 10, {
       tags: ['@main']
     });

--- a/tests/unit/controllers/index-test.js
+++ b/tests/unit/controllers/index-test.js
@@ -14,9 +14,8 @@ module('Unit | Controller | index', function(hooks) {
     let controller = this.owner.lookup('controller:index');
     assert.ok(controller);
     assert.deepEqual(controller.riverQuery, {
-      index: 'gothamist',
-      count: TOTAL_COUNT,
-      page: 2,
+      limit: TOTAL_COUNT,
+      show_on_index_listing: true,
     });
   });
 


### PR DESCRIPTION
[ticket](https://jira.wnyc.org/browse/CMS-546)

The `BASE_COUNT` const in the index route had to get lowered in order to meet a server requirement. When the server constrain is lifted, that value can be return to `28`.

This adds a `homepage` mirage factory, even though it's not currently used, but may be useful in the future.