### PR TITLE
use `idForComments` field for comment counts

### DIFF
--- a/app/utils/add-comment-count.js
+++ b/app/utils/add-comment-count.js
@@ -1,6 +1,8 @@
 import DS from 'ember-data';
 import fetch from 'fetch';
 
+import { get } from '@ember/object';
+
 import config from '../config/environment';
 
 
@@ -9,6 +11,10 @@ export const QUERY_PARAMS = {
   forum: 'gothamist',
 };
 export const BASE = `${config.disqusAPI}/threads/set.json`;
+
+const DEFAULT_OPS = {
+  ident: 'id',
+};
 
 /**
   Takes the given model or list of models (aka RecordArray) and fetches their comment count
@@ -20,13 +26,14 @@ export const BASE = `${config.disqusAPI}/threads/set.json`;
   @param modelOrRecordArray {DS.Model|DS.RecordArray}
   @return {void}
 */
-export default async function addCommentCount(modelOrRecordArray) {
+export default async function addCommentCount(modelOrRecordArray, ops = {}) {
+  ops = {...DEFAULT_OPS, ...ops};
   let qp = Object.keys(QUERY_PARAMS).map(key => `${key}=${QUERY_PARAMS[key]}`);
 
   if (modelOrRecordArray instanceof DS.Model) {
-    qp.push(`thread:ident=${modelOrRecordArray.id}`);
+    qp.push(`thread:ident=${get(modelOrRecordArray, ops.ident)}`);
   } else if (modelOrRecordArray instanceof DS.RecordArray) {
-    modelOrRecordArray.mapBy('id').forEach(id => qp.push(`thread:ident=${id}`));
+    modelOrRecordArray.mapBy(ops.ident).forEach(ident => qp.push(`thread:ident=${ident}`));
   }
 
   let res;
@@ -51,7 +58,7 @@ export default async function addCommentCount(modelOrRecordArray) {
     response.forEach(thread => {
       let { identifiers, posts } = thread;
       let [ id ] = identifiers;
-      let article = modelOrRecordArray.findBy('id', id);
+      let article = modelOrRecordArray.findBy(ops.ident, id);
       if (article) {
         article.set('commentCount', posts);
       }

--- a/app/utils/add-comment-count.js
+++ b/app/utils/add-comment-count.js
@@ -13,7 +13,7 @@ export const QUERY_PARAMS = {
 export const BASE = `${config.disqusAPI}/threads/set.json`;
 
 const DEFAULT_OPS = {
-  ident: 'id',
+  ident: 'idForComments',
 };
 
 /**

--- a/app/utils/add-comment-count.js
+++ b/app/utils/add-comment-count.js
@@ -12,7 +12,7 @@ export const QUERY_PARAMS = {
 };
 export const BASE = `${config.disqusAPI}/threads/set.json`;
 
-const DEFAULT_OPS = {
+const DEFAULT_OPTIONS = {
   ident: 'idForComments',
 };
 
@@ -26,14 +26,14 @@ const DEFAULT_OPS = {
   @param modelOrRecordArray {DS.Model|DS.RecordArray}
   @return {void}
 */
-export default async function addCommentCount(modelOrRecordArray, ops = {}) {
-  ops = {...DEFAULT_OPS, ...ops};
+export default async function addCommentCount(modelOrRecordArray, options = {}) {
+  options = {...DEFAULT_OPTIONS, ...options};
   let qp = Object.keys(QUERY_PARAMS).map(key => `${key}=${QUERY_PARAMS[key]}`);
 
   if (modelOrRecordArray instanceof DS.Model) {
-    qp.push(`thread:ident=${get(modelOrRecordArray, ops.ident)}`);
+    qp.push(`thread:ident=${get(modelOrRecordArray, options.ident)}`);
   } else if (modelOrRecordArray instanceof DS.RecordArray) {
-    modelOrRecordArray.mapBy(ops.ident).forEach(ident => qp.push(`thread:ident=${ident}`));
+    modelOrRecordArray.mapBy(options.ident).forEach(ident => qp.push(`thread:ident=${ident}`));
   }
 
   let res;
@@ -58,7 +58,7 @@ export default async function addCommentCount(modelOrRecordArray, ops = {}) {
     response.forEach(thread => {
       let { identifiers, posts } = thread;
       let [ id ] = identifiers;
-      let article = modelOrRecordArray.findBy(ops.ident, id);
+      let article = modelOrRecordArray.findBy(options.ident, id);
       if (article) {
         article.set('commentCount', posts);
       }

--- a/mirage/factories/article.js
+++ b/mirage/factories/article.js
@@ -81,8 +81,6 @@ export default Factory.extend({
     }
   ]),
 
-  legacy_id: () => faker.random.number(50000, 80000),
-
   listing_image: null,
   listing_summary: '',
   listing_title: '',
@@ -137,6 +135,8 @@ export default Factory.extend({
   tags: () => ([]),
 
   title: () => faker.random.words(6),
+
+  uuid: () => faker.random.uuid(),
 
   now: trait({
     publication_date: moment.utc().format(CMS_TIMESTAMP_FORMAT),

--- a/tests/acceptance/author-detail-test.js
+++ b/tests/acceptance/author-detail-test.js
@@ -40,7 +40,7 @@ module('Acceptance | author detail', function(hooks) {
 
   test('author lists get updated with commentCount', async function(assert) {
     const EXPECTED = server.schema.articles.all()
-      .models.map((a, i) => ({posts: Math.ceil(Math.random() * i + 1), identifiers: [a.id]}));
+      .models.map((a, i) => ({posts: Math.ceil(Math.random() * i + 1), identifiers: [a.uuid]}));
 
     server.get(`${config.disqusAPI}/threads/set.json`, {response: EXPECTED});
     await visit(`/staff/${AUTHOR_SLUG}`);
@@ -50,7 +50,8 @@ module('Acceptance | author detail', function(hooks) {
     // assert that articles loaded via "read more" also get updated
     findAll('[data-test-block]').forEach(block => {
       let id = block.dataset.testBlock;
-      let { posts } = EXPECTED.find(d => d.identifiers.includes(id));
+      let { uuid } = server.schema.articles.find(id);
+      let { posts } = EXPECTED.find(d => d.identifiers.includes(uuid));
       assert.ok(block.querySelector('.c-block-meta__comments'), 'comments are rendered');
       assert.dom(block.querySelector('.c-block-meta__comments')).includesText(String(posts));
     });

--- a/tests/acceptance/homepage-test.js
+++ b/tests/acceptance/homepage-test.js
@@ -92,7 +92,7 @@ module('Acceptance | homepage', function(hooks) {
     });
     server.createList('article', TOTAL_COUNT * 2);
     const EXPECTED = server.schema.articles.all()
-      .models.map((a, i) => ({posts: Math.ceil(Math.random() * i + 1), identifiers: [a.id]}));
+      .models.map((a, i) => ({posts: Math.ceil(Math.random() * i + 1), identifiers: [a.uuid]}));
 
     server.get(`${config.disqusAPI}/threads/set.json`, {response: EXPECTED});
 
@@ -103,7 +103,8 @@ module('Acceptance | homepage', function(hooks) {
     // assert that articles loaded via "read more" also get updated
     findAll('[data-test-block]').forEach(block => {
       let id = block.dataset.testBlock;
-      let { posts } = EXPECTED.find(d => d.identifiers.includes(id));
+      let { uuid } = server.schema.articles.find(id);
+      let { posts } = EXPECTED.find(d => d.identifiers.includes(uuid));
       assert.ok(block.querySelector('.c-block-meta__comments'), 'comments are rendered');
       assert.dom(block.querySelector('.c-block-meta__comments')).includesText(String(posts));
     });

--- a/tests/acceptance/section-test.js
+++ b/tests/acceptance/section-test.js
@@ -40,7 +40,7 @@ module('Acceptance | section', function(hooks) {
     });
 
     const EXPECTED = server.schema.articles.where({pageId: '1'})
-      .models.map((a, i) => ({posts: Math.ceil(Math.random() * i + 1), identifiers: [a.id]}));
+      .models.map((a, i) => ({posts: Math.ceil(Math.random() * i + 1), identifiers: [a.uuid]}));
 
     server.get(`${config.disqusAPI}/threads/set.json`, {response: EXPECTED});
 
@@ -51,7 +51,8 @@ module('Acceptance | section', function(hooks) {
     // assert that articles loaded via "read more" also get updated
     findAll('[data-test-block]').forEach(block => {
       let id = block.dataset.testBlock;
-      let { posts } = EXPECTED.find(d => d.identifiers.includes(id));
+      let { uuid } = server.schema.articles.find(id);
+      let { posts } = EXPECTED.find(d => d.identifiers.includes(uuid));
       assert.ok(block.querySelector('.c-block-meta__comments'), 'comments are rendered');
       assert.dom(block.querySelector('.c-block-meta__comments')).includesText(String(posts));
     });

--- a/tests/acceptance/tags-test.js
+++ b/tests/acceptance/tags-test.js
@@ -28,7 +28,7 @@ module('Acceptance | tags', function(hooks) {
   test('tag lists get updated with commentCount', async function(assert) {
     server.createList('article', COUNT * 5, {tags: ['dogs']});
     const EXPECTED = server.schema.articles.all()
-      .models.map((a, i) => ({posts: Math.ceil(Math.random() * i + 1), identifiers: [a.id]}));
+      .models.map((a, i) => ({posts: Math.ceil(Math.random() * i + 1), identifiers: [a.uuid]}));
 
     server.get(`${config.disqusAPI}/threads/set.json`, {response: EXPECTED});
 
@@ -40,7 +40,8 @@ module('Acceptance | tags', function(hooks) {
     // assert that articles loaded via "read more" also get updated
     findAll('[data-test-block]').forEach(block => {
       let id = block.dataset.testBlock;
-      let { posts } = EXPECTED.find(d => d.identifiers.includes(id));
+      let { uuid } = server.schema.articles.find(id);
+      let { posts } = EXPECTED.find(d => d.identifiers.includes(uuid));
       assert.ok(block.querySelector('.c-block-meta__comments'), 'comments are rendered');
       assert.dom(block.querySelector('.c-block-meta__comments')).includesText(String(posts));
     });

--- a/tests/unit/utils/add-comment-count-test.js
+++ b/tests/unit/utils/add-comment-count-test.js
@@ -15,9 +15,9 @@ module('Unit | Utility | add-comment-count', function(hooks) {
   test('it updates an article model', async function(assert) {
     const EXPECTED = 100;
     let store = this.owner.lookup('service:store');
-    const ARTICLE = store.createRecord('article', {id: 'foo'});
+    const ARTICLE = store.createRecord('article', {idForComments: 'foo'});
 
-    let qp = {...QUERY_PARAMS, ...{'thread:ident': ARTICLE.id}};
+    let qp = {...QUERY_PARAMS, ...{'thread:ident': ARTICLE.idForComments}};
     qp = Object.keys(qp).map(k => `${k}=${qp[k]}`);
     this.mock(fetch)
       .expects('default')
@@ -35,7 +35,7 @@ module('Unit | Utility | add-comment-count', function(hooks) {
     let qp = Object.keys(QUERY_PARAMS).map(k => `${k}=${QUERY_PARAMS[k]}`);
 
     for (let id = 0; id < 3; id++) {
-      store.createRecord('article', {id});
+      store.createRecord('article', {idForComments: id});
       qp.push(`thread:ident=${id}`);
     }
 
@@ -45,7 +45,7 @@ module('Unit | Utility | add-comment-count', function(hooks) {
       .resolves(new Response(JSON.stringify({
         response: EXPECTED.map((posts, id) => ({
           posts,
-          identifiers: [String(id)]
+          identifiers: [id]
         })
       )})));
 

--- a/tests/unit/utils/add-comment-count-test.js
+++ b/tests/unit/utils/add-comment-count-test.js
@@ -56,4 +56,24 @@ module('Unit | Utility | add-comment-count', function(hooks) {
     });
 
   });
+
+  test('it can accept a local param to use as a disqus identifier', async function(assert) {
+    const OTHER_VALUE = 'foo';
+    const ID = '123';
+    const EXPECTED = 100;
+
+    const store = this.owner.lookup('service:store');
+    const ARTICLE = store.createRecord('article', {id: ID, other: OTHER_VALUE});
+
+    let qp = {...QUERY_PARAMS, ...{'thread:ident': ARTICLE.other}};
+    qp = Object.keys(qp).map(k => `${k}=${qp[k]}`);
+    this.mock(fetch)
+      .expects('default')
+      .withArgs(`${BASE}?${qp.join('&')}`)
+      .resolves(new Response(JSON.stringify({response: [{posts: EXPECTED}]})));
+
+    await addCommentCount(ARTICLE, {ident: 'other'});
+
+    assert.equal(ARTICLE.commentCount, EXPECTED);
+  });
 });


### PR DESCRIPTION
this patch updates the `addCommentCount` utility to use the new computed attr `idForComments` when checking comment counts against the disqus API. The `addCommentCount` will also support  an option for using a different key for lookup, which enables us to safely update the default to the `idForComments` attr.