### PR TITLE
Update preview route to load gallery model

### DIFF
--- a/app/routes/preview.js
+++ b/app/routes/preview.js
@@ -1,6 +1,8 @@
 import Route from '@ember/routing/route';
 import { get } from '@ember/object';
 import { WAGTAIL_MODEL_TYPE as ARTICLE_TYPE } from '../models/article';
+import RSVP from 'rsvp';
+const { hash } = RSVP;
 
 export default Route.extend({
   model({ identifier, token }) {
@@ -9,19 +11,17 @@ export default Route.extend({
     );
   },
   renderTemplate(controller, model) {
-    if (typeof FastBoot === 'undefined') {
-      switch(get(model, 'meta.type')) {
+    switch(get(model, 'meta.type')) {
       case ARTICLE_TYPE:
-        this.render('article', {
-          model: {
-            article: model,
-            gallery: model.gallery
-          }
+        hash({
+          article: model,
+          gallery: model.gallery
+        }).then(model => {
+          this.render('article', { model })
         })
         break;
       default:
         this._super(...arguments);
-      }
     }
   }
 });

--- a/tests/acceptance/gallery-test.js
+++ b/tests/acceptance/gallery-test.js
@@ -24,7 +24,7 @@ module('Acceptance | gallery', function(hooks) {
     await visit(article.html_path);
 
     assert.dom('[data-test-gallery-lead]').exists();
-    // mirage defualt is 5 slides per gallery
+    // mirage withGallery trait default is 8 slides per gallery
     assert.dom('[data-test-gallery-lead-view-all]').hasText('View all 8')
 
     let preview = find('[data-test-gallery-lead-preview] img');

--- a/tests/acceptance/preview-test.js
+++ b/tests/acceptance/preview-test.js
@@ -27,4 +27,28 @@ module('Acceptance | preview', function(hooks) {
     assert.dom('[data-test-article-body]').hasText('foo');
     assert.dom('[data-test-article-body] [data-test-inserted-ad]').exists({count: 1})
   });
+
+  test('visiting preview article with a gallery', async function(assert) {
+    let identifier = 'preview';
+    let token = '123';
+    let url = `/preview?identifier=${identifier}&token=${token}`;
+
+    // this is a fake article, to make sure the test is hitting the
+    // preview api and not pulling from the articles api
+    server.create('article', {text: 'bar', slug: 'test'});
+
+    // this is the preview article. mirage will serve it from the preview
+    // api because it has an identifier and token
+    let article = server.create('article', {identifier, token, text: 'foo', slug: 'test' }, 'withGallery')
+
+    await visit(url);
+
+    assert.equal(currentURL(), url);
+    assert.dom('[data-test-article-headline]').hasText(article.title);
+    assert.dom('[data-test-article-body]').hasText('foo');
+    assert.dom('[data-test-article-body] [data-test-inserted-ad]').exists({count: 1});
+    assert.dom('[data-test-gallery-lead]').exists();
+    // mirage withGallery trait default is 8 slides per gallery
+    assert.dom('[data-test-gallery-lead-view-all]').hasText('View all 8');
+  });
 });


### PR DESCRIPTION
Updates the preview route so it will work correctly for articles with galleries.