### PR TITLE
Hotfix for Edge

### DIFF
--- a/app/utils/wagtail-api.js
+++ b/app/utils/wagtail-api.js
@@ -109,6 +109,6 @@ export const extractPath = function(url) {
   @param obj {Object}
   @return {Object} the updated object
 */
-export const camelizeObject = obj => Object.fromEntries(
+export const camelizeObject = obj => fromEntries(
   Object.entries(obj || {}).map(([k, v]) => [camelize(k), v])
 )


### PR DESCRIPTION
we have a custom polyfill version of Object.fromEntries that should work in edge. It's already imported at the top of this file.