### PR TITLE
CMS-583 Move banners to every page

### DIFF
--- a/app/components/breaking-news-banner/component.js
+++ b/app/components/breaking-news-banner/component.js
@@ -1,0 +1,5 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+  tagName: '',
+});

--- a/app/components/breaking-news-banner/template.hbs
+++ b/app/components/breaking-news-banner/template.hbs
@@ -1,0 +1,15 @@
+{{#if (get-route-params @news.link)}}
+  <NyprMTextBanner
+    @route={{get-route-params @news.link}}
+    @title={{@news.title}}
+    @timestamp={{timestamp @news.startTime}}
+    @description={{@news.description}}
+  />
+{{else}}
+  <NyprMTextBanner
+    @url={{@news.link}}
+    @title={{@news.title}}
+    @timestamp={{timestamp @news.startTime}}
+    @description={{@news.description}}
+  />
+{{/if}}

--- a/app/components/product-banner/component.js
+++ b/app/components/product-banner/component.js
@@ -1,0 +1,5 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+  tagName: ''
+});

--- a/app/components/product-banner/template.hbs
+++ b/app/components/product-banner/template.hbs
@@ -1,0 +1,33 @@
+<DismissableBlock
+  @cookieId={{@banner.cookieId}}
+  @dismissedFor={{@banner.frequency}}
+  as |dismiss|>
+  <NyprMBoxBanner
+    class={{unless @banner.description 'o-box-banner--no-desc'}}
+    @close={{action dismiss}}
+    data-test-top-product-banner
+    as |box-banner|>
+
+    <box-banner.title>
+      {{{@banner.title}}}
+    </box-banner.title>
+
+    {{#if (or @banner.description @banner.buttonText)}}
+      <box-banner.body as |body|>
+        {{#if @banner.description}}
+          <body.dek>
+            {{{@banner.description}}}
+          </body.dek>
+        {{/if}}
+
+        {{#if @banner.buttonText}}
+          <body.cta>
+            <NyprAButton @url={{@banner.buttonLink}}>
+              {{@banner.buttonText}}
+            </NyprAButton>
+          </body.cta>
+        {{/if}}
+      </box-banner.body>
+    {{/if}}
+  </NyprMBoxBanner>
+</DismissableBlock>

--- a/app/helpers/get-route-params.js
+++ b/app/helpers/get-route-params.js
@@ -16,9 +16,10 @@ import { inject as service } from '@ember/service';
  */
 export default Helper.extend({
   router: service(),
+  fastboot: service(),
   compute([ url ]/*, hash*/) {
     // If we're not in fastboot don't try this.
-    if (window && window.location) {
+    if (!this.fastboot.isFastBoot && url) {
       let origin = `${location.protocol}//${location.host}`;
       url = url.replace(origin, '');
 

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -4,6 +4,7 @@ import DS from 'ember-data';
 import Route from '@ember/routing/route';
 import { get } from '@ember/object';
 import { inject } from '@ember/service';
+import { hash } from 'rsvp';
 import { schedule } from '@ember/runloop';
 import { doTargetingForPath, clearTargetingForPath } from 'nypr-ads';
 import config from '../config/environment';
@@ -57,7 +58,7 @@ export default Route.extend({
   },
 
   model() {
-    return {
+    return hash({
       primaryNav: [{
         route: ['sections', 'news'],
         text: 'News',
@@ -84,8 +85,10 @@ export default Route.extend({
       }, {
         route: ['staff'],
         text: 'Staff'
-      }]
-    }
+      }],
+      systemMessages: this.store.findRecord('system-messages', config.siteId).catch(() => ''),
+      sitewideComponents: this.store.findRecord('sitewide-components', config.siteId).catch(() => ''),
+    });
   },
 
   afterModel(_model, transition) {

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -73,8 +73,6 @@ export default Route.extend({
         limit: TOTAL_COUNT,
         fields: LISTING_FIELDS,
       }).catch(failSafe('river')),
-      systemMessages: this.store.findRecord('system-messages', config.siteId).catch(() => ''),
-      sitewideComponents: this.store.findRecord('sitewide-components', config.siteId).catch(() => ''),
       wnyc: getWnycStories(),
     }).then(results => {
       results.main = results.main.slice();

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -123,10 +123,12 @@ $ember-basic-dropdown-content-z-index: 10000;
 }
 
 // margin and width for ads when columns collapse
-.c-home__sections .c-block-group__col1 {
+.c-home__content-top .c-block-group__col1,
+.c-home__content-bottom .c-block-group__col1 {
   margin-bottom: 24px;
 }
-.c-home__sections .c-block-group__col2 .o-ad {
+.c-home__content-top .c-block-group__col2 .o-ad,
+.c-home__content-bottom .c-block-group__col2 .o-ad {
   width: 300px;
 }
 

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -129,7 +129,7 @@
 </NyprOHeader>
 
 <main class={{concat "c-main " this.mainRouteClasses}}>
-  <div class="c-banners u-section-spacing--wide l-container l-container--xl l-wrap u-trigger-floating-header">
+  <div class="c-banners u-section-spacing--wide l-container l-container--xl l-wrap">
     <div class="c-banners__breaking-news l-container l-container--16col">
       {{#each model.sitewideComponents.breakingNews as |news|}}
         <BreakingNewsBanner @news={{news}} />

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -129,6 +129,18 @@
 </NyprOHeader>
 
 <main class={{concat "c-main " this.mainRouteClasses}}>
+  <div class="c-banners u-section-spacing--wide l-container l-container--xl l-wrap u-trigger-floating-header">
+    <div class="c-banners__breaking-news l-container l-container--16col">
+      {{#each model.sitewideComponents.breakingNews as |news|}}
+        <BreakingNewsBanner @news={{news}} />
+      {{/each}}
+    </div>
+
+    {{#with model.systemMessages.topProductBanner as |productBanner|}}
+      <ProductBanner @banner={{productBanner}} />
+    {{/with}}
+  </div>
+
   {{outlet}}
 </main>
 

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -3,17 +3,7 @@
 <DoTargeting key='Template' value='Homepage' />
 
 <h1 class="is-vishidden" aria-hidden="true">Gothamist: New York City Local News, Food, Arts & Events</h1>
-<div class="c-home__sections u-section-spacing--wide l-container l-container--xl l-wrap u-trigger-floating-header">
-
-  <div class="l-container l-container--16col">
-    {{#each model.sitewideComponents.breakingNews as |news|}}
-      <BreakingNewsBanner @news={{news}} />
-    {{/each}}
-  </div>
-
-  {{#with model.systemMessages.topProductBanner as |productBanner|}}
-    <ProductBanner @banner={{productBanner}} />
-  {{/with}}
+<div class="c-home__content-top u-section-spacing--wide l-container l-container--xl l-wrap">
 
   <NyprOFeaturedBlockList data-test-featured-block-list as |fbl|>
     <fbl.heading>
@@ -134,7 +124,7 @@
   </div>
 </div>
 
-<div class="c-home__sections">
+<div class="c-home__tout">
   <NyprODonate
     @linkUrl='https://pledge3.wnyc.org/donate/gothamist/onestep?utm_medium=partnersite&utm_source=gothamist&utm_campaign=homepagedonationask'
     @linkText='Donate'
@@ -145,7 +135,7 @@
   </NyprODonate>
 </div>
 
-<div class="c-home__sections u-spacing--quad l-container l-wrap">
+<div class="c-home__content-bottom u-spacing--quad l-container l-wrap">
 
   <div class="l-container l-container--14col">
     <ArticleList @articles={{slice (multiply GROUP_SIZE 3) undefined model.river}} @ad='gothamist/index/midpage/3' />

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -5,67 +5,14 @@
 <h1 class="is-vishidden" aria-hidden="true">Gothamist: New York City Local News, Food, Arts & Events</h1>
 <div class="c-home__sections u-section-spacing--wide l-container l-container--xl l-wrap u-trigger-floating-header">
 
-  {{#with model.sitewideComponents.breakingNews as |breaking|}}
-    <div class="l-container l-container--16col">
-      {{#each breaking as |news|}}
-        {{#if (get-route-params news.link)}}
-          <NyprMTextBanner
-            @route={{get-route-params news.link}}
-            @title={{news.title}}
-            @timestamp={{timestamp news.startTime}}
-            @description={{news.description}}
-          />
-        {{else}}
-          <NyprMTextBanner
-            @url={{news.link}}
-            @title={{news.title}}
-            @timestamp={{timestamp news.startTime}}
-            @description={{news.description}}
-          />
-        {{/if}}
-      {{/each}}
-    </div>
-  {{/with}}
+  <div class="l-container l-container--16col">
+    {{#each model.sitewideComponents.breakingNews as |news|}}
+      <BreakingNewsBanner @news={{news}} />
+    {{/each}}
+  </div>
 
   {{#with model.systemMessages.topProductBanner as |productBanner|}}
-    <DismissableBlock
-      @cookieId={{productBanner.cookieId}}
-      @dismissedFor={{productBanner.frequency}}
-      as |dismiss|>
-      <NyprMBoxBanner
-        class={{unless productBanner.description 'o-box-banner--no-desc'}}
-        @close={{action dismiss}}
-        data-test-top-product-banner
-        as |banner|>
-
-        <banner.title>
-          {{{productBanner.title}}}
-        </banner.title>
-
-        {{#if (or productBanner.description productBanner.buttonText)}}
-          <banner.body as |body|>
-            {{#if productBanner.description}}
-              <body.dek>
-                {{{productBanner.description}}}
-              </body.dek>
-            {{/if}}
-
-            {{#if productBanner.buttonText}}
-              <body.cta>
-                <NyprAButton @url={{productBanner.buttonLink}}>
-                  {{productBanner.buttonText}}
-                </NyprAButton>
-              </body.cta>
-            {{/if}}
-          </banner.body>
-        {{/if}}
-
-      </NyprMBoxBanner>
-    </DismissableBlock>
-  {{/with}}
-
-  {{#with model.breaking.firstObject as |breaking|}}
-    <BreakingNews @article={{breaking}} />
+    <ProductBanner @banner={{productBanner}} />
   {{/with}}
 
   <NyprOFeaturedBlockList data-test-featured-block-list as |fbl|>

--- a/tests/acceptance/article-test.js
+++ b/tests/acceptance/article-test.js
@@ -377,7 +377,6 @@ module('Acceptance | article', function(hooks) {
       article.description);
   });
 
-
   test('structured data is correct', async function(assert) {
     const article = server.create('article');
 
@@ -390,5 +389,46 @@ module('Acceptance | article', function(hooks) {
     assert.equal(data.headline, article.title);
     assert.equal(data.description, article.description);
     assert.equal(data.publisher.name, "Gothamist");
+  });
+
+  test('breaking news on article route', async function(assert) {
+    const article = server.create('article', 'withSection', {text: 'foo', section: 'food'});
+    server.createList('article', 5, 'withSection', {
+      show_as_feature: true,
+      show_on_index_listing: true,
+      section: 'food'
+    });
+    server.create('sitewide-component');
+    server.create('breaking-news');
+
+    await visit(`/${article.html_path}`);
+    assert.dom('.c-block--urgent').exists({count: 1});
+
+  });
+
+  test('top product banner on article route', async function(assert) {
+    const article = server.create('article', 'withSection', {text: 'foo', section: 'food'});
+    server.createList('article', 5, 'withSection', {
+      show_as_feature: true,
+      show_on_index_listing: true,
+      section: 'food'
+    });
+    //clear cookie
+    document.cookie = `${config.productBannerCookiePrefix}12345=; expires=${moment().subtract(1, 'day')}; path=/`;
+    // create banner;
+    server.create('system-message');
+    server.create('product-banner', {
+      "id": "12345",
+      "title": "Test Title",
+      "description": "<p>Test Description</p>",
+      "button_text": "Test Button",
+      "button_link": "http://example.com",
+    });
+
+    await visit(`/${article.html_path}`);
+    assert.dom('[data-test-top-product-banner]').exists();
+    assert.dom('[data-test-top-product-banner] .o-box-banner__title').includesText("Test Title");
+    assert.dom('[data-test-top-product-banner] .o-box-banner__dek').includesText("Test Description");
+    assert.dom('[data-test-top-product-banner] .o-box-banner__cta').includesText("Test Button");
   });
 });

--- a/tests/acceptance/article-test.js
+++ b/tests/acceptance/article-test.js
@@ -392,27 +392,21 @@ module('Acceptance | article', function(hooks) {
   });
 
   test('breaking news on article route', async function(assert) {
-    const article = server.create('article', 'withSection', {text: 'foo', section: 'food'});
-    server.createList('article', 5, 'withSection', {
-      show_as_feature: true,
-      show_on_index_listing: true,
-      section: 'food'
-    });
     server.create('sitewide-component');
     server.create('breaking-news');
 
-    await visit(`/${article.html_path}`);
-    assert.dom('.c-block--urgent').exists({count: 1});
-
-  });
-
-  test('top product banner on article route', async function(assert) {
     const article = server.create('article', 'withSection', {text: 'foo', section: 'food'});
     server.createList('article', 5, 'withSection', {
       show_as_feature: true,
       show_on_index_listing: true,
       section: 'food'
     });
+    await visit(`/${article.html_path}`);
+
+    assert.dom('.c-block--urgent').exists({count: 1});
+  });
+
+  test('top product banner on article route', async function(assert) {
     //clear cookie
     document.cookie = `${config.productBannerCookiePrefix}12345=; expires=${moment().subtract(1, 'day')}; path=/`;
     // create banner;
@@ -425,7 +419,14 @@ module('Acceptance | article', function(hooks) {
       "button_link": "http://example.com",
     });
 
+    const article = server.create('article', 'withSection', {text: 'foo', section: 'food'});
+    server.createList('article', 5, 'withSection', {
+      show_as_feature: true,
+      show_on_index_listing: true,
+      section: 'food'
+    });
     await visit(`/${article.html_path}`);
+
     assert.dom('[data-test-top-product-banner]').exists();
     assert.dom('[data-test-top-product-banner] .o-box-banner__title').includesText("Test Title");
     assert.dom('[data-test-top-product-banner] .o-box-banner__dek').includesText("Test Description");

--- a/tests/acceptance/author-detail-test.js
+++ b/tests/acceptance/author-detail-test.js
@@ -1,3 +1,5 @@
+import moment from 'moment';
+
 import { module, test} from 'qunit';
 import { visit, currentURL, click, findAll } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
@@ -55,5 +57,35 @@ module('Acceptance | author detail', function(hooks) {
       assert.ok(block.querySelector('.c-block-meta__comments'), 'comments are rendered');
       assert.dom(block.querySelector('.c-block-meta__comments')).includesText(String(posts));
     });
+  });
+
+  test('breaking news on author route', async function(assert) {
+    server.create('sitewide-component');
+    server.create('breaking-news');
+
+    await visit(`/staff/${AUTHOR_SLUG}`);
+
+    assert.dom('.c-block--urgent').exists({count: 1});
+  });
+
+  test('top product banner on author route', async function(assert) {
+    //clear cookie
+    document.cookie = `${config.productBannerCookiePrefix}12345=; expires=${moment().subtract(1, 'day')}; path=/`;
+    // create banner;
+    server.create('system-message');
+    server.create('product-banner', {
+      "id": "12345",
+      "title": "Test Title",
+      "description": "<p>Test Description</p>",
+      "button_text": "Test Button",
+      "button_link": "http://example.com",
+    });
+
+    await visit(`/staff/${AUTHOR_SLUG}`);
+
+    assert.dom('[data-test-top-product-banner]').exists();
+    assert.dom('[data-test-top-product-banner] .o-box-banner__title').includesText("Test Title");
+    assert.dom('[data-test-top-product-banner] .o-box-banner__dek').includesText("Test Description");
+    assert.dom('[data-test-top-product-banner] .o-box-banner__cta').includesText("Test Button");
   });
 });

--- a/tests/acceptance/section-test.js
+++ b/tests/acceptance/section-test.js
@@ -94,4 +94,42 @@ module('Acceptance | section', function(hooks) {
     assert.dom('[data-test-section-river] [data-test-block="foo"]').doesNotExist('featured articles should be filtered out of the river');
     assert.dom('[data-test-section-river] [data-test-block="bar"]').doesNotExist('featured articles should be filtered out of the river');
   });
+
+  test('breaking news on section route', async function(assert) {
+    server.create('sitewide-component');
+    server.create('breaking-news');
+
+    server.create('page', 'withArticles', {
+      slug: 'news',
+      title: 'News',
+    });
+    await visit('/news');
+
+    assert.dom('.c-block--urgent').exists({count: 1});
+  });
+
+  test('top product banner on section route', async function(assert) {
+    //clear cookie
+    document.cookie = `${config.productBannerCookiePrefix}12345=; expires=${moment().subtract(1, 'day')}; path=/`;
+    // create banner;
+    server.create('system-message');
+    server.create('product-banner', {
+      "id": "12345",
+      "title": "Test Title",
+      "description": "<p>Test Description</p>",
+      "button_text": "Test Button",
+      "button_link": "http://example.com",
+    });
+
+    server.create('page', 'withArticles', {
+      slug: 'news',
+      title: 'News',
+    });
+    await visit('/news');
+
+    assert.dom('[data-test-top-product-banner]').exists();
+    assert.dom('[data-test-top-product-banner] .o-box-banner__title').includesText("Test Title");
+    assert.dom('[data-test-top-product-banner] .o-box-banner__dek').includesText("Test Description");
+    assert.dom('[data-test-top-product-banner] .o-box-banner__cta').includesText("Test Button");
+  });
 });

--- a/tests/integration/components/breaking-news-banner/component-test.js
+++ b/tests/integration/components/breaking-news-banner/component-test.js
@@ -1,0 +1,29 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | breaking-news-banner', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    await render(hbs`<BreakingNewsBanner/>`);
+    assert.dom('.o-text-banner').exists({count: 1});
+  });
+
+  test('it displays the news details', async function(assert) {
+    const NEWS = {
+      title: 'test title',
+      description: 'test description',
+      link: 'http://abc.def'
+    }
+
+    this.set('news', NEWS);
+
+    await render(hbs`<BreakingNewsBanner @news={{news}}/>`);
+
+    assert.dom('.o-text-banner').exists({count: 1});
+    assert.dom('.o-text-banner .c-block__title').containsText(NEWS.title);
+    assert.dom('.o-text-banner .c-block__dek').containsText(NEWS.description);
+  });
+});

--- a/tests/integration/components/product-banner/component-test.js
+++ b/tests/integration/components/product-banner/component-test.js
@@ -1,0 +1,30 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | product-banner', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    await render(hbs`<ProductBanner/>`);
+    assert.dom('.o-box-banner').exists({count: 1});
+  });
+
+  test('it displays the news details', async function(assert) {
+    const BANNER = {
+      title: 'test title',
+      description: 'test description',
+      link: 'http://abc.def'
+    }
+
+    this.set('banner', BANNER);
+
+    await render(hbs`<ProductBanner @banner={{banner}}/>`);
+
+    assert.dom('.o-box-banner').exists({count: 1});
+    assert.dom('.o-box-banner__title').containsText(BANNER.title);
+    assert.dom('.o-box-banner__dek').containsText(BANNER.description);
+  });
+});
+


### PR DESCRIPTION
Moves product and breaking news banners from home to application route, so we get them on every page.
depends on CSS updates in https://github.com/nypublicradio/pattern-lab/pull/73

https://jira.wnyc.org/browse/CMS-583