### PR TITLE
CMS-685 quotes in og description

### DIFF
--- a/app/helpers/stringify.js
+++ b/app/helpers/stringify.js
@@ -1,0 +1,7 @@
+import { helper } from '@ember/component/helper';
+
+export function stringify([data]/*, hash*/) {
+  return JSON.stringify(data);
+}
+
+export default helper(stringify);

--- a/app/routes/article.js
+++ b/app/routes/article.js
@@ -66,7 +66,7 @@ export default Route.extend({
     this.dataLayer.push({template: 'article'});
 
     this.headData.setProperties({
-      metaDescription: JSON.stringify(article.description),
+      metaDescription: article.description,
       ogType: 'article',
       ogTitle: article.title, // don't include " - Gothamist" like in <title> tag
       publishedTime: article.publishedMoment.format(),

--- a/app/templates/head.hbs
+++ b/app/templates/head.hbs
@@ -73,7 +73,7 @@
       "mainEntityOfPage": "https://gothamist.com/{{model.path}}",
       "image": "{{if model.image (wagtail-image-url model.image 1200 650)}}",
       "headline": "{{or model.ogTitle model.title}}",
-      "description": {{model.metaDescription}},
+      "description": {{stringify model.metaDescription}},
       "datePublished": "{{model.publishedTime}}",
       "dateModified": "{{if model.modifiedTime model.modifiedTime}}",
     "author": [

--- a/app/templates/head.hbs
+++ b/app/templates/head.hbs
@@ -72,7 +72,7 @@
       "@type": "NewsArticle",
       "mainEntityOfPage": "https://gothamist.com/{{model.path}}",
       "image": "{{if model.image (wagtail-image-url model.image 1200 650)}}",
-      "headline": "{{model.title}}",
+      "headline": "{{or model.ogTitle model.title}}",
       "description": {{model.metaDescription}},
       "datePublished": "{{model.publishedTime}}",
       "dateModified": "{{if model.modifiedTime model.modifiedTime}}",

--- a/tests/acceptance/article-test.js
+++ b/tests/acceptance/article-test.js
@@ -348,6 +348,26 @@ module('Acceptance | article', function(hooks) {
     assert.equal(spy.secondCall.args[0].virtualReferrer, '/food/foo');
   });
 
+  test('og metadata is correct', async function(assert) {
+    const article = server.create('article');
+
+    await visit(`/${article.html_path}`);
+
+    assert.equal(document.querySelector("meta[property='og:title']")
+      .getAttribute("content"),
+      article.title);
+    assert.equal(document.querySelector("meta[name='twitter:title']")
+      .getAttribute("content"),
+      article.title);
+    assert.equal(document.querySelector("meta[property='og:description']")
+      .getAttribute("content"),
+      article.description);
+    assert.equal(document.querySelector("meta[name='twitter:description']")
+      .getAttribute("content"),
+      article.description);
+  });
+
+
   test('structured data is correct', async function(assert) {
     const article = server.create('article');
 
@@ -357,8 +377,8 @@ module('Acceptance | article', function(hooks) {
 
     assert.equal(data.author[0].name,
       `${article.related_authors[0].first_name} ${article.related_authors[0].last_name}`);
-    assert.equal(data.headline, article.ogTitle);
-    assert.equal(data.description, JSON.stringify(article.description));
+    assert.equal(data.headline, article.title);
+    assert.equal(data.description, article.description);
     assert.equal(data.publisher.name, "Gothamist");
   });
 });

--- a/tests/acceptance/article-test.js
+++ b/tests/acceptance/article-test.js
@@ -347,4 +347,18 @@ module('Acceptance | article', function(hooks) {
     assert.equal(spy.firstCall.args[0].virtualReferrer, '/');
     assert.equal(spy.secondCall.args[0].virtualReferrer, '/food/foo');
   });
+
+  test('structured data is correct', async function(assert) {
+    const article = server.create('article');
+
+    await visit(`/${article.html_path}`);
+
+    let data = JSON.parse(document.querySelector('#structured-data').innerText);
+
+    assert.equal(data.author[0].name,
+      `${article.related_authors[0].first_name} ${article.related_authors[0].last_name}`);
+    assert.equal(data.headline, article.ogTitle);
+    assert.equal(data.description, JSON.stringify(article.description));
+    assert.equal(data.publisher.name, "Gothamist");
+  });
 });

--- a/tests/integration/helpers/stringify-test.js
+++ b/tests/integration/helpers/stringify-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Helper | stringify', function(hooks) {
+  setupRenderingTest(hooks);
+
+  // Replace this with your real tests.
+  test('it json.stringifies a string', async function(assert) {
+    this.set('inputValue', '1234');
+
+    await render(hbs`{{stringify inputValue}}`);
+
+    assert.equal(this.element.textContent.trim(), '"1234"');
+  });
+});


### PR DESCRIPTION
- removes quotes from the og description tags
- also updates the structured data headline to match the article title (without "- Gothamist")