### PR TITLE
CMS-698 credit link

### DIFF
--- a/app/models/article.js
+++ b/app/models/article.js
@@ -149,7 +149,10 @@ export default Page.extend({
     }
     switch(this.leadAsset.type) {
       case LEAD_IMAGE:
-        return camelizeObject(this.leadAsset.value);
+        return {
+          image: camelizeObject(this.leadAsset.value.image),
+          caption: this.leadAsset.value.caption,
+        }
       default:
         if (this.leadAsset.value.default_image) {
           return {

--- a/mirage/factories/article.js
+++ b/mirage/factories/article.js
@@ -74,6 +74,8 @@ export default Factory.extend({
       value: {
         image: {
           id: 1283,
+          credit: faker.name.findName(),
+          credit_link: faker.internet.url(),
         },
         caption: faker.lorem.words(5),
         image_link: faker.internet.url(),

--- a/mirage/factories/gallery.js
+++ b/mirage/factories/gallery.js
@@ -65,6 +65,8 @@ export default Factory.extend({
           slide_image: {
             image: {
               id: faker.random.number(5000),
+              credit: faker.name.findName(),
+              credit_link: faker.internet.url(),
             },
             caption: faker.lorem.sentence(),
           },

--- a/tests/acceptance/article-test.js
+++ b/tests/acceptance/article-test.js
@@ -65,6 +65,16 @@ module('Acceptance | article', function(hooks) {
     assert.dom('[data-test-lead-image] img').exists({count: 1});
     assert.dom('[data-test-lead-image] img').hasAttribute('src', imageUrl);
 
+    // lead image credit
+    const credit = article.lead_asset[0].value.image.credit;
+    assert.dom('[data-test-lead-image] .o-credit').exists({count: 1});
+    assert.dom('[data-test-lead-image] .o-credit').hasText(credit);
+
+    // lead image credit link
+    const creditLink = article.lead_asset[0].value.image.credit_link;
+    assert.dom('[data-test-lead-image] .o-credit a').exists({count: 1});
+    assert.dom('[data-test-lead-image] .o-credit a').hasAttribute('href', creditLink);
+
     // lead image link
     const imageLink = article.lead_asset[0].value.image_link;
     assert.dom('[data-test-lead-image-link]').exists({count: 1});

--- a/tests/acceptance/gallery-test.js
+++ b/tests/acceptance/gallery-test.js
@@ -76,6 +76,21 @@ module('Acceptance | gallery', function(hooks) {
         `image src should have expected path: ${src}`
       );
 
+      // image caption
+      const caption = slide.value.slide_image.caption;
+      assert.dom(`[data-test-gallery-slide="${i}"] .c-slide__dek`).exists({count: 1});
+      assert.dom(`[data-test-gallery-slide="${i}"] .c-slide__dek`).containsText(caption);
+
+      // image credit
+      const credit = slide.value.slide_image.image.credit;
+      assert.dom(`[data-test-gallery-slide="${i}"] .o-credit`).exists({count: 1});
+      assert.dom(`[data-test-gallery-slide="${i}"] .o-credit`).containsText(credit);
+
+      // image credit link
+      const creditLink = slide.value.slide_image.image.credit_link;
+      assert.dom(`[data-test-gallery-slide="${i}"] .o-credit a`).exists({count: 1});
+      assert.dom(`[data-test-gallery-slide="${i}"] .o-credit a`).hasAttribute('href', creditLink);
+
       let mediumSource = find(`[data-test-gallery-slide="${i}"] [data-test-source-m]`);
       assert.ok(
         mediumSource.srcset.match(`images/${id}/width-800`),


### PR DESCRIPTION
Credit links weren't working on the lead image.
https://jira.wnyc.org/browse/CMS-698

The template was looking for `article.leadImage.image.creditLink`, but `image` properties weren't getting camelCased for the lead image.

This adds some tests and fixes that.