### PR TITLE
CMS-746 Fixes for HTL

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -25,7 +25,7 @@ export default Route.extend({
     // for 404 tracking
     this.router.on('routeWillChange', () => {
       this.dataLayer.push({previousPath: this.router.currentURL})
-
+      this.controllerFor('application').set('routeIsChanging', true)
       // reset metrics context before every transition with just the referring URL
       // subsequent updates to pagedata will need to merge with this existing value
       this.set('metrics.context.pageData', {
@@ -37,6 +37,7 @@ export default Route.extend({
     this.router.on('routeDidChange', (transition) => {
       const from = get(transition, 'from.name')
       const to = get(transition, 'to.name')
+      this.controllerFor('application').set('routeIsChanging', false)
       if (from === 'gallery' && to === 'gallery') {
         schedule('afterRender', () => this.dataLayer.push('event', 'Gallery Slide View'));
       } else {

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -25,7 +25,6 @@ export default Route.extend({
     // for 404 tracking
     this.router.on('routeWillChange', () => {
       this.dataLayer.push({previousPath: this.router.currentURL})
-      this.controllerFor('application').set('routeIsChanging', true)
       // reset metrics context before every transition with just the referring URL
       // subsequent updates to pagedata will need to merge with this existing value
       this.set('metrics.context.pageData', {
@@ -37,7 +36,6 @@ export default Route.extend({
     this.router.on('routeDidChange', (transition) => {
       const from = get(transition, 'from.name')
       const to = get(transition, 'to.name')
-      this.controllerFor('application').set('routeIsChanging', false)
       if (from === 'gallery' && to === 'gallery') {
         schedule('afterRender', () => this.dataLayer.push('event', 'Gallery Slide View'));
       } else {

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -12,12 +12,14 @@
   as |header|>
 
   <header.leaderboard>
-    {{#unless (or this.sensitive.on routeIsChanging)}}
-      {{#if (eq target.currentRouteName 'index')}}
-        <AdTagLeaderboard @slot='gothamist/index/leaderboard' />
-      {{else}}
-        <AdTagLeaderboard @slot='gothamist/interior/leaderboard' />
-      {{/if}}
+    {{#unless this.sensitive.on}}
+      {{#unless routeIsChanging}}
+        {{#if (eq target.currentRouteName 'index')}}
+          <AdTagLeaderboard @slot='gothamist/index/leaderboard' />
+        {{else}}
+          <AdTagLeaderboard @slot='gothamist/interior/leaderboard' />
+        {{/if}}
+      {{/unless}}
     {{/unless}}
   </header.leaderboard>
 

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -12,7 +12,7 @@
   as |header|>
 
   <header.leaderboard>
-    {{#unless this.sensitive.on}}
+    {{#unless (or this.sensitive.on routeIsChanging)}}
       {{#if (eq target.currentRouteName 'index')}}
         <AdTagLeaderboard @slot='gothamist/index/leaderboard' />
       {{else}}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -13,13 +13,11 @@
 
   <header.leaderboard>
     {{#unless this.sensitive.on}}
-      {{#unless routeIsChanging}}
-        {{#if (eq target.currentRouteName 'index')}}
-          <AdTagLeaderboard @slot='gothamist/index/leaderboard' />
-        {{else}}
-          <AdTagLeaderboard @slot='gothamist/interior/leaderboard' />
-        {{/if}}
-      {{/unless}}
+      {{#if (eq target.currentRouteName 'index')}}
+        <AdTagLeaderboard @slot='gothamist/index/leaderboard' />
+      {{else}}
+        <AdTagLeaderboard @slot='gothamist/interior/leaderboard' />
+      {{/if}}
     {{/unless}}
   </header.leaderboard>
 

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "jsdom": "^15.1.1",
     "loader.js": "^4.7.0",
     "memory-scroll": "^0.9.1",
-    "nypr-ads-htl": "^0.1.3",
+    "nypr-ads-htl": "^0.1.4",
     "nypr-auth": "^0.2.4",
     "nypr-design-system": "^2.0.4",
     "nypr-metrics": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "jsdom": "^15.1.1",
     "loader.js": "^4.7.0",
     "memory-scroll": "^0.9.1",
-    "nypr-ads-htl": "^0.1.4",
+    "nypr-ads-htl": "^0.1.5",
     "nypr-auth": "^0.2.4",
     "nypr-design-system": "^2.0.4",
     "nypr-metrics": "^0.7.0",

--- a/tests/acceptance/ads-test.js
+++ b/tests/acceptance/ads-test.js
@@ -12,6 +12,7 @@ const HTL_STUB = () => ({
   },
   clearTargeting() {},
   setTargeting() {},
+  removeSlot() {},
   on() {},
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9460,10 +9460,10 @@ nwsapi@^2.0.9, nwsapi@^2.1.4:
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.1.4.tgz#e006a878db23636f8e8a67d33ca0e4edf61a842f"
   integrity sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw==
 
-nypr-ads-htl@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/nypr-ads-htl/-/nypr-ads-htl-0.1.3.tgz#f4840691cec6181bf0c5cc0b944c677af824ca5b"
-  integrity sha512-ZwyE7SLWBmJMOSVJ9p1m3ytQ62ld5Dhbhz1TnuYy7vr40pffP3kMbfjZf5RyohDMEPGjtTx8/U0KbBABAWuP7Q==
+nypr-ads-htl@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/nypr-ads-htl/-/nypr-ads-htl-0.1.4.tgz#56eb70482b11a77cc8c4da73eeaf583ecb47ac9b"
+  integrity sha512-y4i3mYidS4TCO48sjhthPw6BjpYgRy95g87yb4pWEqVW/202HDmzgVE09PNP2z9nkcxweLpipkLmkD2KoH3XnQ==
   dependencies:
     ember-cli-babel "^7.1.2"
     ember-cli-htmlbars "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9460,10 +9460,10 @@ nwsapi@^2.0.9, nwsapi@^2.1.4:
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.1.4.tgz#e006a878db23636f8e8a67d33ca0e4edf61a842f"
   integrity sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw==
 
-nypr-ads-htl@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/nypr-ads-htl/-/nypr-ads-htl-0.1.4.tgz#56eb70482b11a77cc8c4da73eeaf583ecb47ac9b"
-  integrity sha512-y4i3mYidS4TCO48sjhthPw6BjpYgRy95g87yb4pWEqVW/202HDmzgVE09PNP2z9nkcxweLpipkLmkD2KoH3XnQ==
+nypr-ads-htl@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/nypr-ads-htl/-/nypr-ads-htl-0.1.5.tgz#0dd0d4f445412a5f815f79dd2be033ffe708ccc3"
+  integrity sha512-T/bnvug1fhpoOZAjqycboRrbrpKkHlZZYmcbhz8EZe8iHmzLa2e5e2K2SvN/XxgyOUV0csXPAOEvY49maKi38A==
   dependencies:
     ember-cli-babel "^7.1.2"
     ember-cli-htmlbars "^3.0.0"


### PR DESCRIPTION
Imports an updated `nypr-ads-htl` that includes code to handle ad teardown on template changes, fixing some issues with multiple ad calls being made.