### PR TITLE
Add env var toggle for ad lazy-loading

### DIFF
--- a/app/components/ad-tag-inside/component.js
+++ b/app/components/ad-tag-inside/component.js
@@ -2,6 +2,7 @@ import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import { and, not } from '@ember/object/computed';
 import insertAdDiv from '../../utils/insert-ad-div';
+import config from '/gothamist-web-client/config/environment';
 
 export default Component.extend({
   tagName: '',
@@ -15,6 +16,8 @@ export default Component.extend({
   notFastBoot: not('fastboot.isFastBoot'),
   notSensitive: not('sensitive.on'),
   shouldRender: and('wormholeDestination', 'notFastBoot', 'notSensitive'),
+
+  isEager: (!config.lazyLoadAds),
 
   actions: {
     handleDidRender() {

--- a/app/components/ad-tag-inside/component.js
+++ b/app/components/ad-tag-inside/component.js
@@ -2,7 +2,7 @@ import Component from '@ember/component';
 import { inject as service } from '@ember/service';
 import { and, not } from '@ember/object/computed';
 import insertAdDiv from '../../utils/insert-ad-div';
-import config from '/gothamist-web-client/config/environment';
+import config from 'gothamist-web-client/config/environment';
 
 export default Component.extend({
   tagName: '',

--- a/app/components/ad-tag-inside/template.hbs
+++ b/app/components/ad-tag-inside/template.hbs
@@ -17,7 +17,7 @@
       @slot={{@slot}}
       @breakMargins={{true}}
       @showLabel={{true}}
-      @isEager={{true}}
+      @isEager={{this.isEager}}
       data-test-inserted-ad
     />
   {{/ember-wormhole}}

--- a/app/components/ad-tag-tall/component.js
+++ b/app/components/ad-tag-tall/component.js
@@ -1,0 +1,16 @@
+import Component from '@ember/component';
+import config from 'gothamist-web-client/config/environment';
+
+export default Component.extend({
+  classNames: ['ad-tag-wide'],
+
+  isEager: (!config.lazyLoadAds),
+
+  actions: {
+    handleSlotRendered(slot) {
+      if (this.slotRenderEndedAction) {
+        this.slotRenderEndedAction(slot);
+      }
+    }
+  }
+});

--- a/app/components/ad-tag-tall/component.js
+++ b/app/components/ad-tag-tall/component.js
@@ -2,7 +2,7 @@ import Component from '@ember/component';
 import config from 'gothamist-web-client/config/environment';
 
 export default Component.extend({
-  classNames: ['ad-tag-wide'],
+  tagName: '',
 
   isEager: (!config.lazyLoadAds),
 

--- a/app/components/ad-tag-tall/template.hbs
+++ b/app/components/ad-tag-tall/template.hbs
@@ -1,7 +1,7 @@
 <HtlbidAd
   @slot={{@slot}}
   @sizes="0x0:300x250|750x0:300x600,300x250"
-  @isEager={{true}}
+  @isEager={{this.isEager}}
 as |ad|>
   {{ad.tag}}
   {{#unless ad.isEmpty}}

--- a/app/components/ad-tag-wide/component.js
+++ b/app/components/ad-tag-wide/component.js
@@ -1,5 +1,6 @@
 import Component from '@ember/component';
 import { inject } from '@ember/service';
+import config from 'gothamist-web-client/config/environment';
 
 export default Component.extend({
   classNames: ['ad-tag-wide'],
@@ -33,6 +34,8 @@ export default Component.extend({
     @argument slotRenderEndedAction
     @type {function}
   */
+  isEager: (!config.lazyLoadAds),
+
   actions: {
     handleSlotRendered(slot) {
       if (this.slotRenderEndedAction) {

--- a/app/components/ad-tag-wide/template.hbs
+++ b/app/components/ad-tag-wide/template.hbs
@@ -2,7 +2,7 @@
   <HtlbidAd
     @slot={{@slot}}
     @sizes="0x0:300x250,320x50|750x0:300x600,728x90,300x250|1000x0:970x250,970x90,728x90,300x600,300x250"
-    @isEager={{true}}
+    @isEager={{this.isEager}}
     data-test-ad-tag-wide
   as |ad|>
     <div class={{if @breakMargins "break-margins"}}>

--- a/config/environment.js
+++ b/config/environment.js
@@ -66,6 +66,7 @@ module.exports = function(environment) {
     articleViewsCookie: 'goth_articleViews',
     productBannerCookiePrefix: 'gothamist_product_banner_',
     siteId:             Number(process.env.GOTHAMIST_SITE_ID) || 2, //id for system_messages, sitewidecomponents, etc.
+    lazyLoadAds:        !!process.env.LAZY_LOAD_ADS,  // If LAZY_LOAD_ADS exists, turn on lazy loading for non-sticky ads
 
     // for nypr-auth
     etagAPI: process.env.BROWSER_ID_ENDPOINT,
@@ -76,7 +77,7 @@ module.exports = function(environment) {
       disableEagerListenAnalytics: true,
     },
   };
-
+  
   if (environment === 'development') {
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;


### PR DESCRIPTION
Adds an config value `LazyLoadAds` that controls whether or not our non-sticky (everything but the wrapper and header slots) ads use lazy loading or not.

This value is turned set to true by the presence of a LAZY_LOAD_ADS environment variable.

This isn't as good as a self-serve solution for adops would be, but for the time being, at least gives us the ability to toggle lazy loading on and off without further code changes.