### PR TITLE
 CMS-853 disable recirc on preview

### DIFF
--- a/app/routes/article.js
+++ b/app/routes/article.js
@@ -129,6 +129,7 @@ export default Route.extend({
     // have not closed the donation tout in the past 24 hours
     let showTout = this.cookies.read(articleViewsCookie) >= 3 && !this.cookies.exists(donateCookie);
     controller.set('showTout', showTout);
+    controller.set('isPreview', false);
   },
 
   resetController(controller) {

--- a/app/routes/gallery.js
+++ b/app/routes/gallery.js
@@ -103,7 +103,6 @@ export default Route.extend({
     controller.set('isPreview', false);
   },
 
-
   resetController(controller, isExiting) {
     if (isExiting) {
       // don't save gallery position

--- a/app/routes/gallery.js
+++ b/app/routes/gallery.js
@@ -97,6 +97,13 @@ export default Route.extend({
     }
   },
 
+  setupController(controller) {
+    this._super(...arguments);
+
+    controller.set('isPreview', false);
+  },
+
+
   resetController(controller, isExiting) {
     if (isExiting) {
       // don't save gallery position

--- a/app/routes/preview.js
+++ b/app/routes/preview.js
@@ -34,5 +34,9 @@ export default Route.extend({
       default:
         this._super(...arguments);
     }
-  }
+  },
+  setupController(controller) {
+    this._super(...arguments);
+    controller.set('isPreview', true);
+  },
 });

--- a/app/routes/preview.js
+++ b/app/routes/preview.js
@@ -20,11 +20,9 @@ export default Route.extend({
     );
   },
   renderTemplate(controller, model) {
-    let previewedController;
     switch(get(model, 'meta.type')) {
       case ARTICLE_TYPE:
-        previewedController = this.controllerFor('article');
-        previewedController.set('isPreview', true);
+        this.controllerFor('article').set('isPreview', true);
         hash({
           article: model,
           gallery: resolve(model.gallery)
@@ -34,8 +32,7 @@ export default Route.extend({
         });
         break;
       case GALLERY_TYPE:
-        previewedController = this.controllerFor('gallery');
-        previewedController.set('isPreview', true);
+        this.controllerFor('gallery').set('isPreview', true);
         hash({
           gallery: model,
           articles: model.relatedArticles,

--- a/app/routes/preview.js
+++ b/app/routes/preview.js
@@ -13,8 +13,11 @@ export default Route.extend({
     );
   },
   renderTemplate(controller, model) {
+    let previewedController;
     switch(get(model, 'meta.type')) {
       case ARTICLE_TYPE:
+        previewedController = this.controllerFor('article');
+        previewedController.set('isPreview', true);
         hash({
           article: model,
           gallery: resolve(model.gallery)
@@ -24,6 +27,8 @@ export default Route.extend({
         });
         break;
       case GALLERY_TYPE:
+        previewedController = this.controllerFor('gallery');
+        previewedController.set('isPreview', true);
         hash({
           gallery: model,
           articles: model.relatedArticles,

--- a/app/templates/article.hbs
+++ b/app/templates/article.hbs
@@ -162,7 +162,9 @@
     </div>
 
     <div class="l-container l-container--14col">
-      <ArticleRecirc @article={{model.article}}/>
+      {{#unless isPreview}}
+          <ArticleRecirc @article={{if model.article}}/>
+      {{/unless}}
     </div>
 
   </article>

--- a/app/templates/article.hbs
+++ b/app/templates/article.hbs
@@ -163,7 +163,7 @@
 
     <div class="l-container l-container--14col">
       {{#unless isPreview}}
-          <ArticleRecirc @article={{model.article}}/>
+        <ArticleRecirc @article={{model.article}}/>
       {{/unless}}
     </div>
 

--- a/app/templates/article.hbs
+++ b/app/templates/article.hbs
@@ -163,7 +163,7 @@
 
     <div class="l-container l-container--14col">
       {{#unless isPreview}}
-          <ArticleRecirc @article={{if model.article}}/>
+          <ArticleRecirc @article={{model.article}}/>
       {{/unless}}
     </div>
 


### PR DESCRIPTION
This disables the recirc module on preview and adds a 'Cache-Control': 'no-cache' header to the preview route.