### PR TITLE
Don't include alternative styles in prod.

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -2,6 +2,8 @@
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
+var env = process.env.ENV;
+
 module.exports = function(defaults) {
   let app = new EmberApp(defaults, {
     sourcemaps: {
@@ -20,7 +22,9 @@ module.exports = function(defaults) {
       exclude: ['png'], // default images
     },
     'nypr-design-system': {
-      themes: ['gothamist', 'white-label', 'deprecated']
+      themes: env && env.toUpperCase() === 'PROD' ?
+        ['gothamist'] :
+        ['gothamist', 'white-label', 'deprecated']
     },
     SRI: {
       // JS preload fails due to a bug in chromium


### PR DESCRIPTION
Update `nypr-design-system` config to only include Gothamist styles, with no alternative style sheets, when ENV is set to prod.

ENV is an environment variable that's set by CircleCI when we build.
we have two sets of env vars preconfigured in CircleCI, prefixed with PROD_ or DEMO_ and the prefixes get removed as part of the build process. (this should all be in the circle.yml file)

for example, when we're running a prod deploy, the variable PROD_ENV (which has a value of 'prod', as configured in the CircleCI dashboard) will get renamed (copied?) to an environment variable called ENV, which is what i'm reading in the `ember-cli-build.js` here to determine which theme style sheet(s) to include.