### PR TITLE
`ADVERTISEMENT` label displays underneath mid-page ads on sections pages (eg, `/foods`)

### DIFF
--- a/app/components/ad-tag-inside/template.hbs
+++ b/app/components/ad-tag-inside/template.hbs
@@ -16,7 +16,6 @@
     <AdTagWide
       @slot={{@slot}}
       @breakMargins={{true}}
-      @showLabel={{true}}
       @isEager={{this.isEager}}
       data-test-inserted-ad
     />

--- a/app/components/ad-tag-wide/component.js
+++ b/app/components/ad-tag-wide/component.js
@@ -14,13 +14,6 @@ export default Component.extend({
   */
   slot: undefined,
   /**
-    When true, displays an 'ADVERTISING' label.
-
-    @argument showLabel
-    @type {boolean}
-  */
-  showLabel: false,
-  /**
     When true adds markup and classes for
     breaking out of horizontal margins.
 

--- a/app/components/ad-tag-wide/template.hbs
+++ b/app/components/ad-tag-wide/template.hbs
@@ -8,9 +8,9 @@
     <div class={{if @breakMargins "break-margins"}}>
       <div class="flex-wrapper">
         {{ad.tag}}
-        {{#if (and @showLabel (not ad.isEmpty))}}
+        {{#unless ad.isEmpty}}
           <NyprAAdLabel/>
-        {{/if}}
+        {{/unless}}
       </div>
     </div>
     {{#if (and @breakMargins (not ad.isEmpty))}}

--- a/app/templates/article.hbs
+++ b/app/templates/article.hbs
@@ -158,7 +158,6 @@
           <AdTagWide
             @slot="gothamist/interior/midpage/2"
             @breakMargins={{true}}
-            @showLabel={{true}}
           />
         </footer.ad>
 

--- a/app/templates/gallery.hbs
+++ b/app/templates/gallery.hbs
@@ -16,8 +16,7 @@
     (eq index 2)
   )}}
     <gallery.billboard>
-      <AdTagWide @slot="gothamist/interior/midpage/gallery"
-      @showLabel={{true}} />
+      <AdTagWide @slot="gothamist/interior/midpage/gallery" />
     </gallery.billboard>
   {{/if}}
 </NyprOGalleryOverlay>

--- a/app/templates/tags.hbs
+++ b/app/templates/tags.hbs
@@ -72,7 +72,6 @@
 
   <div class="c-listing__ad o-ad o-ad--billboard">
     <AdTagWide @slot="gothamist/interior/midpage/1" />
-    <NyprAAdLabel/>
   </div>
 
   <hr class="u-border-accent u-hide-until--m" aria-hidden="true">
@@ -114,7 +113,6 @@
 
         <div class="c-listing__ad o-ad o-ad--billboard">
           <AdTagWide @slot="gothamist/interior/midpage/repeating" />
-          <NyprAAdLabel/>
         </div>
 
         <hr class="u-border-accent u-hide-until--m" aria-hidden="true">


### PR DESCRIPTION
I removed the `showLabel` parameter of the `AdTagWide` component because as far as I can tell there are no use cases for the `ADVERTISEMENT` label to be hidden. This enabled me to also consolidate calls to `NyprAAdLabel` to the `AdTagWide` component, thus removing a potential and/or unreported bug in which the `ADVERTISEMENT` label would display if the ad unit is empty.