### PR TITLE
rollback nypr-ads-htl

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "jsdom": "^15.1.1",
     "loader.js": "^4.7.0",
     "memory-scroll": "^0.9.1",
-    "nypr-ads-htl": "nypublicradio/nypr-ads-htl#ecdd6c40b63d7a77e5724c59d132883dd28e116d",
+    "nypr-ads-htl": "0.1.5",
     "nypr-auth": "^0.2.4",
     "nypr-design-system": "3.1.5",
     "nypr-metrics": "^0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11651,9 +11651,10 @@ nwsapi@^2.1.4:
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.1.4.tgz#e006a878db23636f8e8a67d33ca0e4edf61a842f"
   integrity sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw==
 
-nypr-ads-htl@nypublicradio/nypr-ads-htl#ecdd6c40b63d7a77e5724c59d132883dd28e116d:
+nypr-ads-htl@0.1.5:
   version "0.1.5"
-  resolved "https://codeload.github.com/nypublicradio/nypr-ads-htl/tar.gz/ecdd6c40b63d7a77e5724c59d132883dd28e116d"
+  resolved "https://registry.yarnpkg.com/nypr-ads-htl/-/nypr-ads-htl-0.1.5.tgz#0dd0d4f445412a5f815f79dd2be033ffe708ccc3"
+  integrity sha512-T/bnvug1fhpoOZAjqycboRrbrpKkHlZZYmcbhz8EZe8iHmzLa2e5e2K2SvN/XxgyOUV0csXPAOEvY49maKi38A==
   dependencies:
     ember-cli-babel "^7.1.2"
     ember-cli-htmlbars "^3.0.0"


### PR DESCRIPTION
rollback nypr-ads-htl to v0.1.5