### PR TITLE
Whitelist sentry error reports to only scripts served from our domains

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -41,6 +41,7 @@ module.exports = function(environment) {
       sentry: {
         dsn: process.env.SENTRY_DSN,
         tracesSampleRate: 1.0,
+        whitelistUrls: [/gothamist-client\.demo\.nypr\.digital/, /gothamist\.com/],
       }
     },
 


### PR DESCRIPTION
Right now we're getting lots of sentry errors reports from ads, external analytics scripts, chrome extensions, etc. This config change will cut down on a big chunk of the noise by limiting reports to only errors from our scripts.