### PR TITLE
GOTH-53 Update head metadata with social overrides from tag page API

### DIFF
--- a/app/routes/tags.js
+++ b/app/routes/tags.js
@@ -19,6 +19,7 @@ export const COUNT = 12;
 
 export default Route.extend({
   fastboot: inject(),
+  headData: inject(),
   header: inject('nypr-o-header'),
   dataLayer: inject('nypr-metrics/data-layer'),
 
@@ -46,7 +47,7 @@ export default Route.extend({
       page: this.store.queryRecord('tag', {
         html_path: `tags/${tag}`
         // eslint-disable-next-line no-unused-vars
-      }).catch(error => { return }),
+      }).catch(error => ({})),
       articles: this.store.query('article', {
         tag_slug: tag,
         limit: COUNT,
@@ -61,6 +62,13 @@ export default Route.extend({
       }
       return results;
     })
+  },
+
+  afterModel(model) {
+    let { page } = model;
+    if (page.socialTitle) { this.headData.set('ogTitle', page.socialTitle)}
+    if (page.socialText) { this.headData.set('metaDescription', page.socialText)}
+    if (page.socialImage) { this.headData.set('image', page.socialImage)}
   },
 
   setupController(controller, model) {

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -78,10 +78,17 @@ export default function() {
     // add a trailing slash to match server expectations
     html_path = html_path.replace(/([^/]+)$/, '$1/');
 
+    if (html_path.startsWith("tags/")) {
+      let slug = html_path.split('/')[1];
+      return schema['tagpages'].where({slug});
+    }
+
     let found = searchAllCollections({ html_path }, schema);
 
     return found || new Response(404);
   });
+
+
 
   // elasticsearch endpoint
   this.get('/api/v2/search/', function(schema, { queryParams }) {

--- a/mirage/factories/tagpage.js
+++ b/mirage/factories/tagpage.js
@@ -1,0 +1,37 @@
+import PageFactory from './page'
+import { faker } from 'ember-cli-mirage';
+
+export default PageFactory.extend({
+  type: "tagpages.TagPage",
+  designed_header: () => ([
+    {
+      type: 'image',
+      value: {
+        image: {
+          id: 3234,
+          credit: faker.name.findName(),
+          credit_link: faker.internet.url(),
+        },
+        caption: faker.lorem.words(5),
+        image_link: faker.internet.url(),
+      },
+      id: faker.random.uuid(),
+    }
+  ]),
+  top_page_zone() {
+    let copy = this.text || faker.lorem.paragraphs(4).split("\n ").join('</p><p>');
+    return [{
+      type: 'paragraph',
+      value: `<p>${copy}</p>`,
+      id: faker.random.uuid(),
+    }];
+  },
+  midpage_zone() {
+    let copy = this.text || faker.lorem.paragraphs(4).split("\n ").join('</p><p>');
+    return [{
+      type: 'paragraph',
+      value: `<p>${copy}</p>`,
+      id: faker.random.uuid(),
+    }];
+  },
+});

--- a/mirage/models/tagpage.js
+++ b/mirage/models/tagpage.js
@@ -1,0 +1,5 @@
+import { Model, hasMany } from 'ember-cli-mirage';
+
+export default Model.extend({
+  descendants: hasMany('article'),
+});

--- a/public/robots-demo.txt
+++ b/public/robots-demo.txt
@@ -1,4 +1,9 @@
 # http://www.robotstxt.org
+
+# Allow Twitterbot so we can use the Twitter card validator
+User-agent: Twitterbot
+Disallow:
+
 User-agent: *
 Disallow: /
 Sitemap: /sitemap.xml

--- a/tests/acceptance/homepage-test.js
+++ b/tests/acceptance/homepage-test.js
@@ -47,7 +47,7 @@ module('Acceptance | homepage', function(hooks) {
     server.create('wnyc-story', {id: 'gothamist-wnyc-crossposting'});
 
     await visit(`/`);
-    
+
     const title = 'Gothamist: New York City Local News, Food, Arts & Events';
     const desc = 'Gothamist is a website about New York City news, arts and events, and food, brought to you by New York Public Radio.';
     const imagePath = window.location.origin + config.fallbackMetadataImage;

--- a/tests/acceptance/tags-test.js
+++ b/tests/acceptance/tags-test.js
@@ -80,4 +80,32 @@ module('Acceptance | tags', function(hooks) {
     assert.dom('[data-test-top-product-banner] .o-box-banner__dek').includesText("Test Description");
     assert.dom('[data-test-top-product-banner] .o-box-banner__cta').includesText("Test Button");
   });
+
+  test('og metadata for curated tag page is correct', async function(assert) {
+    const TITLE = 'Custom Title';
+    const DESCRIPTION = 'Custom Description';
+    const IMAGE_ID = 12345;
+    const IMAGE_PATH = `https://example.com/images/${IMAGE_ID}/fill-1200x650/`;
+
+    server.create('tagpage', {
+      slug: 'dogs-and-cats',
+      social_title: TITLE,
+      social_text: DESCRIPTION,
+      social_image: {id: IMAGE_ID}
+    })
+    server.createList('article', COUNT * 5, {tags: [{slug: 'dogs-and-cats', name: 'dogs and cats'}], section: 'food', tag_slug: 'dogs-and-cats'});
+
+    await visit('/tags/dogs-and-cats');
+
+    assert.equal(document.querySelector("meta[property='og:title']")
+      .getAttribute("content"), TITLE);
+    assert.equal(document.querySelector("meta[name='twitter:title']")
+      .getAttribute("content"), TITLE);
+    assert.equal(document.querySelector("meta[property='og:description']")
+      .getAttribute("content"), DESCRIPTION);
+    assert.equal(document.querySelector("meta[property='og:image']")
+      .getAttribute("content"), IMAGE_PATH);
+    assert.equal(document.querySelector("meta[property='twitter:image']")
+      .getAttribute("content"), IMAGE_PATH);
+  });
 });


### PR DESCRIPTION
Updates the head metadata properties with title, description, and image from social override fields on the tag page, if available.

Copied in some mirage testing stuff from some in progress PRs to make writing the test easeir