### PR TITLE
GOTH-59 use capitalization from tag's name field instead of all lowercase on tag page heading

### DIFF
--- a/app/routes/tags.js
+++ b/app/routes/tags.js
@@ -60,6 +60,8 @@ export default Route.extend({
         e.url = `tags/${results.tag}`;
         throw e;
       }
+      // get tag name from first article
+      results.title = results.articles.firstObject.tags.findBy('slug', tag)['name']
       return results;
     })
   },

--- a/app/routes/tags.js
+++ b/app/routes/tags.js
@@ -19,6 +19,7 @@ export const COUNT = 12;
 
 export default Route.extend({
   fastboot: inject(),
+  headData: inject(),
   header: inject('nypr-o-header'),
   dataLayer: inject('nypr-metrics/data-layer'),
 
@@ -46,7 +47,7 @@ export default Route.extend({
       page: this.store.queryRecord('tag', {
         html_path: `tags/${tag}`
         // eslint-disable-next-line no-unused-vars
-      }).catch(error => { return }),
+      }).catch(error => ({})),
       articles: this.store.query('article', {
         tag_slug: tag,
         limit: COUNT,
@@ -61,6 +62,13 @@ export default Route.extend({
       }
       return results;
     })
+  },
+
+  afterModel(model) {
+    let { page } = model;
+    if (page.socialTitle) { this.headData.set('ogTitle', page.socialTitle)}
+    if (page.socialText) { this.headData.set('metaDescription', page.socialText)}
+    if (page.socialImage) { this.headData.set('image', page.socialImage)}
   },
 
   setupController(controller, model) {

--- a/mirage/config.js
+++ b/mirage/config.js
@@ -78,10 +78,17 @@ export default function() {
     // add a trailing slash to match server expectations
     html_path = html_path.replace(/([^/]+)$/, '$1/');
 
+    if (html_path.startsWith("tags/")) {
+      let slug = html_path.split('/')[1];
+      return schema['tagpages'].where({slug});
+    }
+
     let found = searchAllCollections({ html_path }, schema);
 
     return found || new Response(404);
   });
+
+
 
   // elasticsearch endpoint
   this.get('/api/v2/search/', function(schema, { queryParams }) {

--- a/mirage/factories/tagpage.js
+++ b/mirage/factories/tagpage.js
@@ -1,0 +1,37 @@
+import PageFactory from './page'
+import { faker } from 'ember-cli-mirage';
+
+export default PageFactory.extend({
+  type: "tagpages.TagPage",
+  designed_header: () => ([
+    {
+      type: 'image',
+      value: {
+        image: {
+          id: 3234,
+          credit: faker.name.findName(),
+          credit_link: faker.internet.url(),
+        },
+        caption: faker.lorem.words(5),
+        image_link: faker.internet.url(),
+      },
+      id: faker.random.uuid(),
+    }
+  ]),
+  top_page_zone() {
+    let copy = this.text || faker.lorem.paragraphs(4).split("\n ").join('</p><p>');
+    return [{
+      type: 'paragraph',
+      value: `<p>${copy}</p>`,
+      id: faker.random.uuid(),
+    }];
+  },
+  midpage_zone() {
+    let copy = this.text || faker.lorem.paragraphs(4).split("\n ").join('</p><p>');
+    return [{
+      type: 'paragraph',
+      value: `<p>${copy}</p>`,
+      id: faker.random.uuid(),
+    }];
+  },
+});

--- a/mirage/models/tagpage.js
+++ b/mirage/models/tagpage.js
@@ -1,0 +1,5 @@
+import { Model, hasMany } from 'ember-cli-mirage';
+
+export default Model.extend({
+  descendants: hasMany('article'),
+});

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "memory-scroll": "^0.9.1",
     "nypr-ads-htl": "0.1.5",
     "nypr-auth": "^0.2.4",
-    "nypr-design-system": "nypublicradio/nypr-design-system#mwalsh/GOTH-59",
+    "nypr-design-system": "^3.1.25",
     "nypr-metrics": "^0.7.0",
     "qunit-dom": "^0.8.0",
     "sass": "^1.17.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "memory-scroll": "^0.9.1",
     "nypr-ads-htl": "0.1.5",
     "nypr-auth": "^0.2.4",
-    "nypr-design-system": "3.1.24",
+    "nypr-design-system": "nypublicradio/nypr-design-system#mwalsh/GOTH-59",
     "nypr-metrics": "^0.7.0",
     "qunit-dom": "^0.8.0",
     "sass": "^1.17.0",

--- a/public/robots-demo.txt
+++ b/public/robots-demo.txt
@@ -1,4 +1,9 @@
 # http://www.robotstxt.org
+
+# Allow Twitterbot so we can use the Twitter card validator
+User-agent: Twitterbot
+Disallow:
+
 User-agent: *
 Disallow: /
 Sitemap: /sitemap.xml

--- a/tests/acceptance/homepage-test.js
+++ b/tests/acceptance/homepage-test.js
@@ -47,7 +47,7 @@ module('Acceptance | homepage', function(hooks) {
     server.create('wnyc-story', {id: 'gothamist-wnyc-crossposting'});
 
     await visit(`/`);
-    
+
     const title = 'Gothamist: New York City Local News, Food, Arts & Events';
     const desc = 'Gothamist is a website about New York City news, arts and events, and food, brought to you by New York Public Radio.';
     const imagePath = window.location.origin + config.fallbackMetadataImage;

--- a/tests/acceptance/tags-test.js
+++ b/tests/acceptance/tags-test.js
@@ -80,4 +80,32 @@ module('Acceptance | tags', function(hooks) {
     assert.dom('[data-test-top-product-banner] .o-box-banner__dek').includesText("Test Description");
     assert.dom('[data-test-top-product-banner] .o-box-banner__cta').includesText("Test Button");
   });
+
+  test('og metadata for curated tag page is correct', async function(assert) {
+    const TITLE = 'Custom Title';
+    const DESCRIPTION = 'Custom Description';
+    const IMAGE_ID = 12345;
+    const IMAGE_PATH = `https://example.com/images/${IMAGE_ID}/fill-1200x650/`;
+
+    server.create('tagpage', {
+      slug: 'dogs-and-cats',
+      social_title: TITLE,
+      social_text: DESCRIPTION,
+      social_image: {id: IMAGE_ID}
+    })
+    server.createList('article', COUNT * 5, {tags: [{slug: 'dogs-and-cats', name: 'dogs and cats'}], section: 'food', tag_slug: 'dogs-and-cats'});
+
+    await visit('/tags/dogs-and-cats');
+
+    assert.equal(document.querySelector("meta[property='og:title']")
+      .getAttribute("content"), TITLE);
+    assert.equal(document.querySelector("meta[name='twitter:title']")
+      .getAttribute("content"), TITLE);
+    assert.equal(document.querySelector("meta[property='og:description']")
+      .getAttribute("content"), DESCRIPTION);
+    assert.equal(document.querySelector("meta[property='og:image']")
+      .getAttribute("content"), IMAGE_PATH);
+    assert.equal(document.querySelector("meta[property='twitter:image']")
+      .getAttribute("content"), IMAGE_PATH);
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -12881,9 +12881,10 @@ nypr-auth@^0.2.4:
     ember-get-config "^0.2.2"
     ember-simple-auth "^1.7.0"
 
-nypr-design-system@nypublicradio/nypr-design-system#mwalsh/GOTH-59:
-  version "3.1.22"
-  resolved "https://codeload.github.com/nypublicradio/nypr-design-system/tar.gz/4e39410d6cde6ef518088fb53756293f112e08e9"
+nypr-design-system@^3.1.25:
+  version "3.1.25"
+  resolved "https://registry.yarnpkg.com/nypr-design-system/-/nypr-design-system-3.1.25.tgz#18b8e6eaaa769ab50ab35f346de30c3627423e42"
+  integrity sha512-LuzUItKwp85OOZy1i+Lc9mUoQJof8X2dgjNDDLlXFOYnyKFjsXkIAdnU2qu+QwqKg/GnD6NcE0QXxYqhkk0jFA==
   dependencies:
     "@babel/core" "^7.0.0"
     "@panosvoudouris/addon-versions" "^1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12881,10 +12881,9 @@ nypr-auth@^0.2.4:
     ember-get-config "^0.2.2"
     ember-simple-auth "^1.7.0"
 
-nypr-design-system@3.1.24:
-  version "3.1.24"
-  resolved "https://registry.yarnpkg.com/nypr-design-system/-/nypr-design-system-3.1.24.tgz#7b1ec7006b0f0bffd36d96d76b37b290a8c27128"
-  integrity sha512-HoB6Lviy1ptxQr6tI4eOqBrjcfDhmITDp39+HM2QEXxwi/UceeHMwX0QYECE0Tz7Vk0WDFVejaDkugzQjHOoLQ==
+nypr-design-system@nypublicradio/nypr-design-system#mwalsh/GOTH-59:
+  version "3.1.22"
+  resolved "https://codeload.github.com/nypublicradio/nypr-design-system/tar.gz/4e39410d6cde6ef518088fb53756293f112e08e9"
   dependencies:
     "@babel/core" "^7.0.0"
     "@panosvoudouris/addon-versions" "^1.0.1"


### PR DESCRIPTION
- previously we weren't getting the tag name at all, just generating from the url slug
- instead of making a new API call to the snippets/tags api, we get the tag name out of the tags field of the first article
- also updated a css rule that made this heading always lowercase: https://github.com/nypublicradio/nypr-design-system/pull/183

Before merging this:
- [x] Merge and release https://github.com/nypublicradio/nypr-design-system/pull/183, and point this to a real version of nypr-design-system
