### PR TITLE
possible fix for canonical url test?

### DIFF
--- a/tests/acceptance/head-test.js
+++ b/tests/acceptance/head-test.js
@@ -30,7 +30,7 @@ module("Acceptance | head component", function (hooks) {
     await visit(`/food/${article.slug}`);
 
     assert.notEqual(
-      document.querySelector("link[rel=canonical").href,
+      document.querySelector("link[rel=canonical]").href,
       "http://localhost"
     );
   });


### PR DESCRIPTION
Potential fix for a flaky test that sometimes caused our circleCI builds to fail.

It looks like a typo in this test created an invalid CSS selector string. It doesn't seem to cause a js exception when i run it on it's own and I don't understand at all why this sort of thing would be non-deterministic, but nevertheless it's close enough to the problematic test that i'm very suspicious.

Reran it a few times on circle to see what happens and didn't get a failure, but because the issue was intermittent there's no way to know for sure if this fixes it, unless it doesn't. Seems like a fix worth merging regardless.