### PR TITLE
adding an internal location for handling proxying to fastboot from newsletter

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -90,10 +90,35 @@ http {
         set_by_lua_block $fastboot_host {
             return "gothamist-client." .. ngx.shared.upstream:get("env") .. ".nypr.digital"
         }
+        set_by_lua_block $gothamist_header {
+            if ngx.shared.upstream:get("env") == "prod" then
+                return "gothamist.com"
+            else
+                return  "gothamist-client." .. ngx.shared.upstream:get("env") .. ".nypr.digital"
+            end
+        }
 
         location / {
+            # If certain query params are present, this location is being hit by a link from the newsletter
+            # Because of this, we need to set the host header to gothamist.com. Otherwise, fastboot will redirect
+            # users to gothamist-client.prod.nypr.digital urls.
+            error_page 419 @newsletter;
+            if ($args ~ "mc_cid") { return 419; }
+
             include headers.conf;
             include microcache.conf;
+            proxy_pass http://fastboot;
+            rewrite ^/(.*)/$ /$1 permanent;
+        }
+
+        location @newsletter {
+            proxy_set_header Host $gothamist_header;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $remote_addr;
+            proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;
+
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
             proxy_pass http://fastboot;
             rewrite ^/(.*)/$ /$1 permanent;
         }


### PR DESCRIPTION
This creates an error page for HTTP Code 419 (which isn't implemented by HTTP servers) which gives us a modicum of certainty that the proxied server won't return it and accidentally trigger the match to the internal location.

Within that internal location block, we mimic exactly the behavior of the `/` location with the exception of using `gothamist.com` as the host header instead of `gothamist-client.prod.nypr.digital`